### PR TITLE
feat: User profile page without posts

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -54,7 +54,6 @@
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
@@ -62,13 +61,43 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-kotlin-sync</artifactId>
+            <version>5.3.0</version>
+        </dependency>
+        <dependency>
+        <groupId>org.mongodb</groupId>
+        <artifactId>bson-kotlin</artifactId>
+        <version>5.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-kotlin-extensions</artifactId>
+            <version>5.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.ninja-squad</groupId>
+            <artifactId>springmockk</artifactId>
+            <version>3.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -77,15 +106,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>5.15.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.15.2</version>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo.spring3x</artifactId>
+            <version>4.18.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/backend/src/main/kotlin/de/neuefische/backend/common/Medium.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/common/Medium.kt
@@ -1,0 +1,17 @@
+package de.neuefische.backend.common
+
+enum class Medium (val lowercase: String){
+    ACRYLIC("acrylic"),
+    CHARCOAL("charcoal"),
+    COLOR_PENCILS("color pencils"),
+    CRAYONS("crayons"),
+    DIGITAL("digital"),
+    GUACHE("guache"),
+    INK("ink"),
+    MARKERS("markers"),
+    OIL("oil"),
+    PAN_PASTELS("pan pastels"),
+    PASTELS("pastels"),
+    PENCILS("pencils"),
+    WATERCOLORS("watercolor"),
+}

--- a/backend/src/main/kotlin/de/neuefische/backend/common/Medium.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/common/Medium.kt
@@ -6,7 +6,7 @@ enum class Medium (val lowercase: String){
     COLOR_PENCILS("color pencils"),
     CRAYONS("crayons"),
     DIGITAL("digital"),
-    GUACHE("guache"),
+    GOUACHE("gouache"),
     INK("ink"),
     MARKERS("markers"),
     OIL("oil"),

--- a/backend/src/main/kotlin/de/neuefische/backend/user/User.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/User.kt
@@ -1,0 +1,18 @@
+package de.neuefische.backend.user
+
+import de.neuefische.backend.common.Medium
+import org.bson.BsonObjectId
+import org.bson.codecs.pojo.annotations.BsonId
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+
+@Document("user")
+data class User(
+    @BsonId
+    val id: BsonObjectId = BsonObjectId(),
+    @Indexed(unique = true)
+    val name: String,
+    val bio: String? = null,
+    val imageUrl: String? = null,
+    val mediums: List<Medium>? = emptyList(),
+)

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserController.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserController.kt
@@ -1,0 +1,22 @@
+package de.neuefische.backend.user
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Controller
+@RequestMapping("api/user")
+class UserController(private val userService: UserService) {
+
+    @GetMapping("/{name}")
+    fun getUser(@PathVariable name: String): ResponseEntity<UserProfileResponse> {
+        val userProfile = userService.getUserByName(name)
+        return if (userProfile != null) {
+            ResponseEntity.ok(userProfile)
+        } else {
+            ResponseEntity.notFound().build()
+        }
+    }
+}

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserController.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserController.kt
@@ -1,12 +1,12 @@
 package de.neuefische.backend.user
 
 import org.springframework.http.ResponseEntity
-import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 
-@Controller
+@RestController
 @RequestMapping("api/user")
 class UserController(private val userService: UserService) {
 

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserProfileResponse.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserProfileResponse.kt
@@ -1,0 +1,9 @@
+package de.neuefische.backend.user
+
+data class UserProfileResponse(
+    val id: String,
+    val name: String,
+    val bio: String?,
+    val imageUrl: String?,
+    val mediums: List<String>
+)

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserRepo.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserRepo.kt
@@ -1,0 +1,9 @@
+package de.neuefische.backend.user
+
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface UserRepo : MongoRepository<User, String> {
+
+    fun findByName(name: String): User?
+
+}

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserService.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserService.kt
@@ -1,0 +1,20 @@
+package de.neuefische.backend.user
+
+import org.springframework.stereotype.Service
+
+@Service
+class UserService(private val userRepo: UserRepo) {
+
+    fun getUserByName(name: String): UserProfileResponse? {
+        return userRepo.findByName(name)?.let { user ->
+            UserProfileResponse(
+                id = user.id.value.toString(),
+                name = user.name,
+                bio = user.bio,
+                imageUrl = user.imageUrl,
+                mediums = user.mediums?.map { it.lowercase } ?: emptyList()
+            )
+        }
+    }
+
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.application.name=TheWorkOfArt
+
+# MONGO Configuration
+spring.data.mongodb.uri=${MONGO_URI}
+spring.data.mongodb.database=TheWorkOfArt

--- a/backend/src/test/kotlin/de/neuefische/backend/user/UserControllerTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/user/UserControllerTest.kt
@@ -1,0 +1,89 @@
+package de.neuefische.backend.user
+
+import com.ninjasquad.springmockk.MockkBean
+import de.neuefische.backend.common.Medium
+import io.mockk.every
+import org.bson.BsonObjectId
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    private lateinit var userRepo: UserRepo
+
+    @Test
+    fun getUserByName() {
+        // Given
+        val user = User(
+            id = BsonObjectId(),
+            name = "test-user",
+            bio = "test-bio",
+            imageUrl = "test-image-url",
+            mediums = listOf(
+                Medium.WATERCOLORS, Medium.INK,
+            )
+        )
+
+        every { userRepo.findByName("test-user") } returns user
+
+        // When
+        val result = mockMvc.perform(get("/api/user/test-user"))
+
+        // Then
+        result.andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").isNotEmpty())
+            .andExpect(jsonPath("$.name").value("test-user"))
+            .andExpect(jsonPath("$.bio").value("test-bio"))
+            .andExpect(jsonPath("$.imageUrl").value("test-image-url"))
+            .andExpect(jsonPath("$.mediums").isArray)
+            .andExpect(jsonPath("$.mediums[0]").value("watercolor"))
+            .andExpect(jsonPath("$.mediums[1]").value("ink"))
+    }
+
+    @Test
+    fun getUserByNameWithoutOptionalFields() {
+        // Given
+        val user = User(
+            id = BsonObjectId(),
+            name = "test-user",
+        )
+
+        every { userRepo.findByName("test-user") } returns user
+
+        // When
+        val result = mockMvc.perform(get("/api/user/test-user"))
+
+        // Then
+        result.andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").isNotEmpty())
+            .andExpect(jsonPath("$.name").value("test-user"))
+            .andExpect(jsonPath("$.bio").value(null))
+            .andExpect(jsonPath("$.imageUrl").value(null))
+            .andExpect(jsonPath("$.mediums").isArray)
+            .andExpect(jsonPath("$.mediums").isEmpty)
+    }
+
+    @Test
+    fun getUserByNameReturnsNotFound() {
+        // Given
+        every { userRepo.findByName("test-user") } returns null
+
+        // When
+        val result = mockMvc.perform(get("/api/user/test-user"))
+
+        // Then
+        result.andExpect(status().isNotFound)
+    }
+}

--- a/backend/src/test/kotlin/de/neuefische/backend/user/UserServiceTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/user/UserServiceTest.kt
@@ -1,0 +1,44 @@
+package de.neuefische.backend.user
+
+import de.neuefische.backend.common.Medium
+import io.mockk.every
+import io.mockk.mockk
+import org.bson.BsonObjectId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class UserServiceTest {
+
+    private val userRepo = mockk<UserRepo>()
+    private val userService = UserService(userRepo)
+
+    @Test
+    fun getUserByName() {
+        // Given
+        val user = User(
+            id = BsonObjectId(),
+            name = "test-user",
+            bio = "test-bio",
+            imageUrl = "test-image-url",
+            mediums = listOf(
+                Medium.WATERCOLORS, Medium.INK,
+            )
+        )
+
+        val expectedResponse = UserProfileResponse(
+            id = user.id.value.toString(),
+            name = "test-user",
+            bio = "test-bio",
+            imageUrl = "test-image-url",
+            mediums = listOf("watercolor", "ink")
+        )
+
+        every { userRepo.findByName("test-user") } returns user
+
+        // When
+        val result = userService.getUserByName("test-user")
+
+        // Then
+        assertEquals(expectedResponse, result)
+    }
+}

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+spring.data.mongodb.port=0
+spring.data.mongodb.database=testdb
+de.flapdoodle.mongodb.embedded.version=7.0.4

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,19 +3,22 @@ import Header from "./components/Header.tsx";
 import Footer from "./components/Footer.tsx";
 import {Route, Routes} from "react-router-dom";
 import Feed from "./pages/Feed.tsx";
+import ProfilePage from "./pages/ProfilePage.tsx";
 
 function App() {
     return (
         <div className="min-h-screen bg-gray-50">
-            <Header />
+            <Header/>
             <main className="container mx-auto px-4 py-8 mt-16">
                 <Routes>
-                    <Route path={"/"} element={<Feed/>} />
-                    <Route path={"/feed"} element={<Feed/>} />
+                    <Route path={"/"} element={<Feed/>}/>
+                    <Route path={"/feed"} element={<Feed/>}/>
+                    <Route path={"/user/:username"} element={<ProfilePage/>}/>
                 </Routes>
             </main>
-            <Footer />
+            <Footer/>
         </div>
     );
 }
+
 export default App

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,7 +13,7 @@ function App() {
                 <Routes>
                     <Route path={"/"} element={<Feed/>}/>
                     <Route path={"/feed"} element={<Feed/>}/>
-                    <Route path={"/user/:username"} element={<ProfilePage/>}/>
+                    <Route path="/user/:username?" element={<ProfilePage/>}/>
                 </Routes>
             </main>
             <Footer/>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -2,6 +2,7 @@ export default function Header() {
 
     const navLinks = [
         {name: "Feed", path: "/feed"},
+        {name: "Profile", path: "/user/alice_jones"},  // TODO: replace with actual username from oauth
     ];
 
     return (

--- a/frontend/src/components/ProfileComponent.tsx
+++ b/frontend/src/components/ProfileComponent.tsx
@@ -18,9 +18,11 @@ export default function UserProfile({username}: UserProfileProps) {
                 setLoading(false);
                 return;
             }
+setLoading(true);  // Reset loading when username changes
             try {
                 const response = await axios.get<User>('/api/user/' + username);
                 setUser(response.data);
+                setError(null); // ✅ Clear previous errors on success
             } catch (error) {
                 setError(error instanceof Error ? error.message : 'An error occurred');
             } finally {

--- a/frontend/src/components/ProfileComponent.tsx
+++ b/frontend/src/components/ProfileComponent.tsx
@@ -24,7 +24,7 @@ setLoading(true);  // Reset loading when username changes
                 setUser(response.data);
                 setError(null); // ✅ Clear previous errors on success
             } catch (error) {
-                setError(error instanceof Error ? error.message : 'An error occurred');
+                setError(error instanceof Error ? error.message : String(error));
             } finally {
                 setLoading(false);
             }

--- a/frontend/src/components/ProfileComponent.tsx
+++ b/frontend/src/components/ProfileComponent.tsx
@@ -1,0 +1,76 @@
+import {useEffect, useState} from "react";
+import axios from "axios";
+import {User} from "../types.tsx";
+
+type UserProfileProps = {
+    username?: string;
+};
+
+export default function UserProfile({username}: UserProfileProps) {
+    const [user, setUser] = useState<User | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        async function fetchUser(username: string | undefined) {
+            if (!username) {
+                setError('Username is required');
+                setLoading(false);
+                return;
+            }
+            try {
+                const response = await axios.get<User>('/api/user/' + username);
+                setUser(response.data);
+            } catch (error) {
+                setError(error instanceof Error ? error.message : 'An error occurred');
+            } finally {
+                setLoading(false);
+            }
+        }
+
+        void fetchUser(username);
+    }, [username]);
+
+    if (loading) return <div className="mt-24 text-center">Loading...</div>;
+    if (error) return <div
+        className="mt-24 text-center text-red-500">Error: {error}</div>;
+    if (!user) return <div className="mt-24 text-center">No user data available</div>;
+
+    return (
+        <div className="container mx-auto px-4 mt-24">
+            <div className="max-w-2xl mx-auto space-y-6">
+                {/* Profile Section */}
+                <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                    <h2 className="text-2xl font-semibold text-gray-800">{user.name}</h2>
+                </div>
+
+                {/* Bio Section */}
+                <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                    <h3 className="text-xl font-semibold text-gray-800 mb-4">Bio</h3>
+                    <p className="text-gray-600">
+                        {user.bio || 'No bio yet 🌳'}
+                    </p>
+                </div>
+
+                {/* Mediums Section */}
+                <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                    <h3 className="text-xl font-semibold text-gray-800 mb-4">Mediums</h3>
+                    {user.mediums && user.mediums.length > 0 ? (
+                        <ul className="space-y-2">
+                            {user.mediums.map((medium) => (
+                                <li
+                                    key={medium}
+                                    className="text-gray-600 py-2 border-b border-gray-100 last:border-0"
+                                >
+                                    {medium}
+                                </li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <p className="text-gray-600">No mediums yet 🖌️</p>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -3,7 +3,7 @@ import {useParams} from "react-router-dom";
 
 export default function ProfilePage() {
 
-    const {username} = useParams<{ username: string }>()
+    const {username} = useParams<{ username?: string }>();  // in case undefined
 
     return (
         <div>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,13 @@
+import UserProfile from "../components/ProfileComponent.tsx";
+import {useParams} from "react-router-dom";
+
+export default function ProfilePage() {
+
+    const {username} = useParams<{ username: string }>()
+
+    return (
+        <div>
+            <UserProfile username={username}/>
+        </div>
+    );
+}

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -4,7 +4,7 @@ export enum Medium {
     COLOR_PENCILS = "color pencils",
     CRAYONS = "crayons",
     DIGITAL = "digital",
-    GUACHE = "guache",
+    GOUACHE = "gouache",
     INK = "ink",
     MARKERS = "markers",
     OIL = "oil",

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -1,0 +1,23 @@
+export enum Medium {
+    ACRYLIC = "acrylic",
+    CHARCOAL = "charcoal",
+    COLOR_PENCILS = "color pencils",
+    CRAYONS = "crayons",
+    DIGITAL = "digital",
+    GUACHE = "guache",
+    INK = "ink",
+    MARKERS = "markers",
+    OIL = "oil",
+    PAN_PASTELS = "pan pastels",
+    PASTELS = "pastels",
+    PENCILS = "pencils",
+    WATERCOLORS = "watercolor"
+}
+
+export type User = {
+    id: string;
+    name: string;
+    bio: string | null;
+    imageUrl: string | null;
+    mediums: Medium[];
+}


### PR DESCRIPTION
Closes #3 

With this PR, a user profile page is added, to show the basic info of a user - name, bio, and preferred art mediums. In the header, the profile link was temporarily hardcoded to point to an existing profile.

On the backend, a GET /api/user/:name endpoint was set up. As this was the first time the database was used, the MongoDB configuration was added as well. 

Data were added in the db manually, as the creation and editing of user profiles will be done at a later stage.

Screenshots after the fixes:

![image](https://github.com/user-attachments/assets/4d3d20ea-541f-4b6b-aae1-dc3b9495ba27)

![image](https://github.com/user-attachments/assets/67c62578-7a2f-49ff-a071-5e731623c866)

