### PR TITLE
feat: Add work of art detail view

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -84,6 +84,11 @@
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.github.microutils</groupId>
+            <artifactId>kotlin-logging-jvm</artifactId>
+            <version>3.0.5</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/backend/src/main/kotlin/de/neuefische/backend/common/Medium.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/common/Medium.kt
@@ -13,5 +13,5 @@ enum class Medium (val lowercase: String){
     PAN_PASTELS("pan pastels"),
     PASTELS("pastels"),
     PENCILS("pencils"),
-    WATERCOLORS("watercolor"),
+    WATERCOLORS("watercolors"),
 }

--- a/backend/src/main/kotlin/de/neuefische/backend/exceptions/ErrorMessage.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/exceptions/ErrorMessage.kt
@@ -1,0 +1,10 @@
+package de.neuefische.backend.exceptions
+
+import org.springframework.http.HttpStatus
+
+
+data class ErrorMessage(
+    val status: HttpStatus,
+    val message: String,
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/backend/src/main/kotlin/de/neuefische/backend/exceptions/GlobalExceptionHandler.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/exceptions/GlobalExceptionHandler.kt
@@ -1,0 +1,28 @@
+package de.neuefische.backend.exceptions
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    fun handleGenericException(exception: Exception): ErrorMessage {
+        return ErrorMessage(
+            status = HttpStatus.INTERNAL_SERVER_ERROR,
+            message = exception.message ?: "An error occurred"
+        )
+    }
+
+    @ExceptionHandler()
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleBadRequestException(exception: IllegalArgumentException): ErrorMessage {
+        return ErrorMessage(
+            status = HttpStatus.BAD_REQUEST,
+            message = exception.message ?: "Bad request"
+        )
+    }
+}

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserController.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserController.kt
@@ -13,9 +13,7 @@ class UserController(private val userService: UserService) {
         @RequestParam(required = false) name: String?
     ): ResponseEntity<UserProfileResponse> {
 
-        if (id == null && name == null) {
-            throw IllegalArgumentException("Either id or name must be provided")
-        }
+        require(!(id == null && name == null)) { "Either id or name must be provided" }
 
         var userProfile: UserProfileResponse? = null
         if (id != null) {

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserController.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserController.kt
@@ -1,18 +1,29 @@
 package de.neuefische.backend.user
 
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/user")
 class UserController(private val userService: UserService) {
 
-    @GetMapping("/{name}")
-    fun getUser(@PathVariable name: String): ResponseEntity<UserProfileResponse> {
-        val userProfile = userService.getUserByName(name)
+    @GetMapping("/")
+    fun getUser(
+        @RequestParam(required = false) id: String?,
+        @RequestParam(required = false) name: String?
+    ): ResponseEntity<UserProfileResponse> {
+
+        if (id == null && name == null) {
+            throw IllegalArgumentException("Either id or name must be provided")
+        }
+
+        var userProfile: UserProfileResponse? = null
+        if (id != null) {
+            userProfile = userService.getUserById(id)
+        } else if (name != null) {
+            userProfile = userService.getUserByName(name)
+        }
+
         return if (userProfile != null) {
             ResponseEntity.ok(userProfile)
         } else {

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserController.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("api/user")
+@RequestMapping("/api/user")
 class UserController(private val userService: UserService) {
 
     @GetMapping("/{name}")

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserService.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserService.kt
@@ -1,5 +1,6 @@
 package de.neuefische.backend.user
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
 @Service
@@ -7,6 +8,18 @@ class UserService(private val userRepo: UserRepo) {
 
     fun getUserByName(name: String): UserProfileResponse? {
         return userRepo.findByName(name)?.let { user ->
+            UserProfileResponse(
+                id = user.id.value.toString(),
+                name = user.name,
+                bio = user.bio,
+                imageUrl = user.imageUrl,
+                mediums = user.mediums?.map { it.lowercase } ?: emptyList()
+            )
+        }
+    }
+
+    fun getUserById(id: String): UserProfileResponse? {
+        return userRepo.findByIdOrNull(id)?.let { user ->
             UserProfileResponse(
                 id = user.id.value.toString(),
                 name = user.name,

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/Material.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/Material.kt
@@ -1,0 +1,12 @@
+package de.neuefische.backend.woa
+
+import de.neuefische.backend.common.Medium
+
+data class Material(
+    val name: String,                  // Cadmium Yellow
+    val identifier: String? = null,    // 24
+    val brand: String? = null,         // Schmincke
+    val line: String? = null,          // Horadam
+    val type: String? = null,          // Tube
+    val medium: Medium? = null         // Watercolor
+)

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/MaterialResponse.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/MaterialResponse.kt
@@ -1,0 +1,10 @@
+package de.neuefische.backend.woa
+
+data class MaterialResponse(
+    val name: String,
+    val identifier: String? = null,
+    val brand: String? = null,
+    val line: String? = null,
+    val type: String? = null,
+    val medium: String? = null
+)

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArt.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArt.kt
@@ -1,0 +1,21 @@
+package de.neuefische.backend.woa
+
+import de.neuefische.backend.common.Medium
+import org.bson.BsonObjectId
+import org.bson.codecs.pojo.annotations.BsonId
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+
+@Document("woa")
+data class WorkOfArt(
+    @BsonId
+    val id: BsonObjectId = BsonObjectId(),
+    val user: BsonObjectId,
+    val challengeId: BsonObjectId? = null,
+    val title: String,
+    val description: String? = null,
+    val imageUrl: String,
+    val medium: Medium,
+    val materials: List<Material>? = emptyList(),
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtController.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtController.kt
@@ -1,6 +1,5 @@
 package de.neuefische.backend.woa
 
-import mu.KotlinLogging
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtController.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtController.kt
@@ -1,0 +1,24 @@
+package de.neuefische.backend.woa
+
+import mu.KotlinLogging
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/woa")
+class WorkOfArtController(private val workOfArtService: WorkOfArtService) {
+
+    @GetMapping("/{id}")
+    fun getWorkOfArt(@PathVariable id: String): ResponseEntity<WorkOfArtResponse> {
+
+        val workOfArt = workOfArtService.getWorkOfArtById(id)
+        return if (workOfArt != null) {
+            ResponseEntity.ok(workOfArt)
+        } else {
+            ResponseEntity.notFound().build()
+        }
+    }
+}

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtRepo.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtRepo.kt
@@ -1,0 +1,6 @@
+package de.neuefische.backend.woa
+
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface WorkOfArtRepo : MongoRepository<WorkOfArt, String> {
+}

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtResponse.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtResponse.kt
@@ -1,0 +1,12 @@
+package de.neuefische.backend.woa
+
+data class WorkOfArtResponse(
+    val id: String,
+    val user: String,
+    val challengeId: String? = null,
+    val title: String,
+    val description: String? = null,
+    val imageUrl: String,
+    val medium: String,
+    val materials: List<MaterialResponse>? = emptyList(),
+)

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtResponse.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtResponse.kt
@@ -9,4 +9,5 @@ data class WorkOfArtResponse(
     val imageUrl: String,
     val medium: String,
     val materials: List<MaterialResponse>? = emptyList(),
+    val createdAt: String,
 )

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtService.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtService.kt
@@ -26,7 +26,8 @@ class WorkOfArtService(private val workOfArtRepo: WorkOfArtRepo) {
                         type = material.type,
                         medium = material.medium?.lowercase,
                     )
-                } ?: emptyList()
+                } ?: emptyList(),
+                createdAt = workOfArt.createdAt.toString(),
             )
         }
     }

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtService.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtService.kt
@@ -1,0 +1,33 @@
+package de.neuefische.backend.woa
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class WorkOfArtService(private val workOfArtRepo: WorkOfArtRepo) {
+
+    fun getWorkOfArtById(id: String): WorkOfArtResponse? {
+
+        return workOfArtRepo.findByIdOrNull(id)?.let { workOfArt ->
+            WorkOfArtResponse(
+                id = workOfArt.id.value.toString(),
+                user = workOfArt.user.value.toString(),
+                challengeId = workOfArt.challengeId?.value?.toString(),
+                title = workOfArt.title,
+                description = workOfArt.description,
+                imageUrl = workOfArt.imageUrl,
+                medium = workOfArt.medium.lowercase,
+                materials = workOfArt.materials?.map { material ->
+                    MaterialResponse(
+                        name = material.name,
+                        identifier = material.identifier,
+                        brand = material.brand,
+                        line = material.line,
+                        type = material.type,
+                        medium = material.medium?.lowercase,
+                    )
+                } ?: emptyList()
+            )
+        }
+    }
+}

--- a/backend/src/main/resources/logback.xml
+++ b/backend/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} MDC=%X{user} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/backend/src/main/resources/logback.xml
+++ b/backend/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
         </encoder>
     </appender>
 
-    <root level="debug">
+    <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/backend/src/test/kotlin/de/neuefische/backend/user/UserControllerTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/user/UserControllerTest.kt
@@ -48,7 +48,7 @@ class UserControllerTest {
             .andExpect(jsonPath("$.bio").value("test-bio"))
             .andExpect(jsonPath("$.imageUrl").value("test-image-url"))
             .andExpect(jsonPath("$.mediums").isArray)
-            .andExpect(jsonPath("$.mediums[0]").value("watercolor"))
+            .andExpect(jsonPath("$.mediums[0]").value("watercolors"))
             .andExpect(jsonPath("$.mediums[1]").value("ink"))
     }
 

--- a/backend/src/test/kotlin/de/neuefische/backend/user/UserControllerTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/user/UserControllerTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -39,7 +40,7 @@ class UserControllerTest {
         every { userRepo.findByName("test-user") } returns user
 
         // When
-        val result = mockMvc.perform(get("/api/user/test-user"))
+        val result = mockMvc.perform(get("/api/user/").param("name", "test-user"))
 
         // Then
         result.andExpect(status().isOk)
@@ -63,7 +64,7 @@ class UserControllerTest {
         every { userRepo.findByName("test-user") } returns user
 
         // When
-        val result = mockMvc.perform(get("/api/user/test-user"))
+        val result = mockMvc.perform(get("/api/user/").param("name", "test-user"))
 
         // Then
         result.andExpect(status().isOk)
@@ -81,9 +82,86 @@ class UserControllerTest {
         every { userRepo.findByName("test-user") } returns null
 
         // When
-        val result = mockMvc.perform(get("/api/user/test-user"))
+        val result = mockMvc.perform(get("/api/user/").param("name", "test-user"))
 
         // Then
         result.andExpect(status().isNotFound)
     }
+
+    @Test
+    fun getUserById() {
+        // Given
+        val userId = BsonObjectId()
+        val user = User(
+            id = userId,
+            name = "test-user",
+            bio = "test-bio",
+            imageUrl = "test-image-url",
+            mediums = listOf(
+                Medium.WATERCOLORS, Medium.INK,
+            )
+        )
+
+        every { userRepo.findByIdOrNull(userId.value.toString()) } returns user
+
+        // When
+        val result = mockMvc.perform(get("/api/user/").param("id", userId.value.toString()))
+
+        // Then
+        result.andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(userId.value.toString()))
+            .andExpect(jsonPath("$.name").value("test-user"))
+            .andExpect(jsonPath("$.bio").value("test-bio"))
+            .andExpect(jsonPath("$.imageUrl").value("test-image-url"))
+            .andExpect(jsonPath("$.mediums").isArray)
+            .andExpect(jsonPath("$.mediums[0]").value("watercolors"))
+            .andExpect(jsonPath("$.mediums[1]").value("ink"))
+    }
+
+    @Test
+    fun getUserByIdWithoutOptionalFields() {
+        // Given
+        val userId = BsonObjectId()
+        val user = User(
+            id = userId,
+            name = "test-user",
+        )
+
+        every { userRepo.findByIdOrNull(userId.value.toString()) } returns user
+
+        // When
+        val result = mockMvc.perform(get("/api/user/").param("id", userId.value.toString()))
+
+        // Then
+        result.andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(userId.value.toString()))
+            .andExpect(jsonPath("$.name").value("test-user"))
+            .andExpect(jsonPath("$.bio").value(null))
+            .andExpect(jsonPath("$.imageUrl").value(null))
+            .andExpect(jsonPath("$.mediums").isArray)
+            .andExpect(jsonPath("$.mediums").isEmpty)
+    }
+
+    @Test
+    fun getUserByIdReturnsNotFound() {
+        // Given
+        val userId = BsonObjectId()
+        every { userRepo.findByIdOrNull(userId.value.toString()) } returns null
+
+        // When
+        val result = mockMvc.perform(get("/api/user/").param("id", userId.value.toString()))
+
+        // Then
+        result.andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun getUserWithoutParametersReturnsBadRequest() {
+        // When
+        val result = mockMvc.perform(get("/api/user/"))
+
+        // Then
+        result.andExpect(status().isBadRequest)
+    }
+
 }

--- a/backend/src/test/kotlin/de/neuefische/backend/user/UserServiceTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/user/UserServiceTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import org.bson.BsonObjectId
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
 
 class UserServiceTest {
 
@@ -40,5 +41,61 @@ class UserServiceTest {
 
         // Then
         assertEquals(expectedResponse, result)
+    }
+
+    // add test for nonexistent name
+    @Test
+    fun getUserByNameNonExistent() {
+        // Given
+        every { userRepo.findByName("test-user") } returns null
+
+        // When
+        val result: UserProfileResponse? = userService.getUserByName("test-user")
+
+        // Then
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun getUserById() {
+        // Given
+        val user = User(
+            id = BsonObjectId(),
+            name = "test-user",
+            bio = "test-bio",
+            imageUrl = "test-image-url",
+            mediums = listOf(
+                Medium.WATERCOLORS, Medium.INK,
+            )
+        )
+
+        val expectedResponse = UserProfileResponse(
+            id = user.id.value.toString(),
+            name = "test-user",
+            bio = "test-bio",
+            imageUrl = "test-image-url",
+            mediums = listOf("watercolors", "ink")
+        )
+
+        every { userRepo.findByIdOrNull(user.id.value.toString()) } returns user
+
+        // When
+        val result = userService.getUserById(user.id.value.toString())
+
+        // Then
+        assertEquals(expectedResponse, result)
+    }
+
+    // add test for nonexistent id
+    @Test
+    fun getUserByIdNonExistent() {
+        // Given
+        every { userRepo.findByIdOrNull("test-id") } returns null
+
+        // When
+        val result: UserProfileResponse? = userService.getUserById("test-id")
+
+        // Then
+        assertEquals(null, result)
     }
 }

--- a/backend/src/test/kotlin/de/neuefische/backend/user/UserServiceTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/user/UserServiceTest.kt
@@ -30,7 +30,7 @@ class UserServiceTest {
             name = "test-user",
             bio = "test-bio",
             imageUrl = "test-image-url",
-            mediums = listOf("watercolor", "ink")
+            mediums = listOf("watercolors", "ink")
         )
 
         every { userRepo.findByName("test-user") } returns user

--- a/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtControllerTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtControllerTest.kt
@@ -86,6 +86,7 @@ class WorkOfArtControllerTest {
             .andExpect(jsonPath("$.materials[1].line").value("Maestro"))
             .andExpect(jsonPath("$.materials[1].type").value("Paintbrush"))
             .andExpect(jsonPath("$.materials[1].medium").doesNotExist())
+            .andExpect(jsonPath("$.createdAt").value(workOfArt.createdAt.toString()))
     }
 
     @Test
@@ -133,5 +134,6 @@ class WorkOfArtControllerTest {
             .andExpect(jsonPath("$.imageUrl").value("test-image-url"))
             .andExpect(jsonPath("$.medium").value("gouache"))
             .andExpect(jsonPath("$.materials").isEmpty())
+            .andExpect(jsonPath("$.createdAt").value(workOfArt.createdAt.toString()))
     }
 }

--- a/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtControllerTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtControllerTest.kt
@@ -1,0 +1,137 @@
+package de.neuefische.backend.woa
+
+import com.ninjasquad.springmockk.MockkBean
+import de.neuefische.backend.common.Medium
+import io.mockk.every
+import org.bson.BsonObjectId
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class WorkOfArtControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    private lateinit var workOfArtRepo: WorkOfArtRepo
+
+    // GET /api/woa/{id}
+    @Test
+    fun getWorkOfArtById() {
+
+        // Given
+        val workOfArtId = BsonObjectId()
+        val workOfArtUserId = BsonObjectId()
+        val workOfArtChallengeId = BsonObjectId()
+
+        val workOfArt = WorkOfArt(
+            id = workOfArtId,
+            user = workOfArtUserId,
+            challengeId = workOfArtChallengeId,
+            title = "test-title",
+            description = "test-description",
+            imageUrl = "test-image-url",
+            medium = Medium.WATERCOLORS,
+            materials = listOf(
+                Material(
+                    name = "Yellow Cadmium 24",
+                    identifier = "24",
+                    brand = "Schmincke",
+                    line = "Horadam",
+                    type = "Half Pan",
+                    medium = Medium.WATERCOLORS,
+                ),
+                Material(
+                    name = "Round Brush",
+                    brand = "Da Vinci",
+                    line = "Maestro",
+                    type = "Paintbrush",
+                ),
+            ),
+        )
+
+        every { workOfArtRepo.findByIdOrNull(workOfArtId.value.toString()) } returns workOfArt
+
+        // When
+        val result = mockMvc.perform(get("/api/woa/${workOfArtId.value}"))
+
+        // Then
+        result.andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(workOfArtId.value.toString()))
+            .andExpect(jsonPath("$.user").value(workOfArtUserId.value.toString()))
+            .andExpect(jsonPath("$.challengeId").value(workOfArtChallengeId.value.toString()))
+            .andExpect(jsonPath("$.title").value("test-title"))
+            .andExpect(jsonPath("$.description").value("test-description"))
+            .andExpect(jsonPath("$.imageUrl").value("test-image-url"))
+            .andExpect(jsonPath("$.medium").value("watercolors"))
+            .andExpect(jsonPath("$.materials").isArray)
+            .andExpect(jsonPath("$.materials[0].name").value("Yellow Cadmium 24"))
+            .andExpect(jsonPath("$.materials[0].identifier").value("24"))
+            .andExpect(jsonPath("$.materials[0].brand").value("Schmincke"))
+            .andExpect(jsonPath("$.materials[0].line").value("Horadam"))
+            .andExpect(jsonPath("$.materials[0].type").value("Half Pan"))
+            .andExpect(jsonPath("$.materials[0].medium").value("watercolors"))
+            .andExpect(jsonPath("$.materials[1].name").value("Round Brush"))
+            .andExpect(jsonPath("$.materials[1].identifier").doesNotExist())
+            .andExpect(jsonPath("$.materials[1].brand").value("Da Vinci"))
+            .andExpect(jsonPath("$.materials[1].line").value("Maestro"))
+            .andExpect(jsonPath("$.materials[1].type").value("Paintbrush"))
+            .andExpect(jsonPath("$.materials[1].medium").doesNotExist())
+    }
+
+    @Test
+    fun getWorkOfArtByIdReturnsNotFound() {
+
+        // Given
+        val workOfArtId = BsonObjectId()
+
+        every { workOfArtRepo.findByIdOrNull(workOfArtId.value.toString()) } returns null
+
+        // When
+        val result = mockMvc.perform(get("/api/woa/${workOfArtId.value}"))
+
+        // Then
+        result.andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun getWorkOfArtByIdWithOnlyRequiredFields() {
+
+        // Given
+        val workOfArtId = BsonObjectId()
+        val workOfArtUserId = BsonObjectId()
+
+        val workOfArt = WorkOfArt(
+            id = workOfArtId,
+            user = workOfArtUserId,
+            title = "test-title",
+            imageUrl = "test-image-url",
+            medium = Medium.GOUACHE,
+        )
+
+        every { workOfArtRepo.findByIdOrNull(workOfArtId.value.toString()) } returns workOfArt
+
+        // When
+        val result = mockMvc.perform(get("/api/woa/${workOfArtId.value}"))
+
+        // Then
+        result.andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(workOfArtId.value.toString()))
+            .andExpect(jsonPath("$.user").value(workOfArtUserId.value.toString()))
+            .andExpect(jsonPath("$.challengeId").doesNotExist())
+            .andExpect(jsonPath("$.title").value("test-title"))
+            .andExpect(jsonPath("$.description").doesNotExist())
+            .andExpect(jsonPath("$.imageUrl").value("test-image-url"))
+            .andExpect(jsonPath("$.medium").value("gouache"))
+            .andExpect(jsonPath("$.materials").isEmpty())
+    }
+}

--- a/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
@@ -1,0 +1,111 @@
+package de.neuefische.backend.woa
+
+import de.neuefische.backend.common.Medium
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.bson.BsonObjectId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+
+class WorkOfArtServiceTest {
+
+    private val workOfArtRepo = mockk<WorkOfArtRepo>()
+    private val workOfArtService = WorkOfArtService(workOfArtRepo)
+
+    @Test
+    fun getWorkOfArtById() {
+
+        // Given
+        val yellowCadmium24 = Material(
+            name = "Yellow Cadmium 24",
+            identifier = "24",
+            brand = "Schmincke",
+            line = "Horadam",
+            type = "Half Pan",
+            medium = Medium.WATERCOLORS,
+        )
+        val paintbrush = Material(
+            // This one has some missing fields
+            name = "Round Brush",
+            brand = "Da Vinci",
+            line = "Maestro",
+            type = "Paintbrush",
+        )
+
+        val workOfArt = WorkOfArt(
+            id = BsonObjectId(),
+            user = BsonObjectId(),
+            challengeId = BsonObjectId(),
+            title = "test-title",
+            description = "test-description",
+            imageUrl = "test-image-url",
+            medium = Medium.WATERCOLORS,
+            materials = listOf(yellowCadmium24, paintbrush),
+        )
+
+        val expectedResponse = WorkOfArtResponse(
+            id = workOfArt.id.value.toString(),
+            user = workOfArt.user.value.toString(),
+            challengeId = workOfArt.challengeId?.value.toString(),
+            title = "test-title",
+            description = "test-description",
+            imageUrl = "test-image-url",
+            medium = "watercolors",
+            materials = listOf(
+                MaterialResponse(
+                    name = "Yellow Cadmium 24",
+                    identifier = "24",
+                    brand = "Schmincke",
+                    line = "Horadam",
+                    type = "Half Pan",
+                    medium = "watercolors",
+                ),
+                MaterialResponse(
+                    name = "Round Brush",
+                    brand = "Da Vinci",
+                    line = "Maestro",
+                    type = "Paintbrush",
+                )
+            )
+        )
+
+        every { workOfArtRepo.findByIdOrNull(workOfArt.id.value.toString()) } returns workOfArt
+
+        // When
+        val result = workOfArtService.getWorkOfArtById(workOfArt.id.value.toString())
+
+        // Then
+        assertEquals(expectedResponse, result)
+    }
+
+    @Test
+    fun getWorkOfArtByIdWithOnlyRequiredFields() {
+
+        // Given
+        val workOfArt = WorkOfArt(
+            id = BsonObjectId(),
+            user = BsonObjectId(),
+            title = "test-title",
+            imageUrl = "test-image-url",
+            medium = Medium.PAN_PASTELS,
+        )
+
+        val expectedResponse = WorkOfArtResponse(
+            id = workOfArt.id.value.toString(),
+            user = workOfArt.user.value.toString(),
+            title = "test-title",
+            imageUrl = "test-image-url",
+            medium = "pan pastels",
+        )
+
+        every { workOfArtRepo.findByIdOrNull(workOfArt.id.value.toString()) } returns workOfArt
+
+        // When
+        val result = workOfArtService.getWorkOfArtById(workOfArt.id.value.toString())
+
+        // Then
+        assertEquals(expectedResponse, result)
+    }
+}

--- a/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
@@ -3,7 +3,6 @@ package de.neuefische.backend.woa
 import de.neuefische.backend.common.Medium
 import io.mockk.every
 import io.mockk.mockk
-import org.assertj.core.api.Assertions.assertThat
 import org.bson.BsonObjectId
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
@@ -67,7 +67,8 @@ class WorkOfArtServiceTest {
                     line = "Maestro",
                     type = "Paintbrush",
                 )
-            )
+            ),
+            createdAt = workOfArt.createdAt.toString(),
         )
 
         every { workOfArtRepo.findByIdOrNull(workOfArt.id.value.toString()) } returns workOfArt
@@ -97,6 +98,7 @@ class WorkOfArtServiceTest {
             title = "test-title",
             imageUrl = "test-image-url",
             medium = "pan pastels",
+            createdAt = workOfArt.createdAt.toString(),
         )
 
         every { workOfArtRepo.findByIdOrNull(workOfArt.id.value.toString()) } returns workOfArt

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import Footer from "./components/Footer.tsx";
 import {Route, Routes} from "react-router-dom";
 import Feed from "./pages/Feed.tsx";
 import ProfilePage from "./pages/ProfilePage.tsx";
+import WorkOfArtPage from "./pages/WorkOfArtPage.tsx";
 
 function App() {
     return (
@@ -14,6 +15,7 @@ function App() {
                     <Route path={"/"} element={<Feed/>}/>
                     <Route path={"/feed"} element={<Feed/>}/>
                     <Route path="/user/:username?" element={<ProfilePage/>}/>
+                    <Route path={"/woa/:workOfArtId?"} element={<WorkOfArtPage/>}/>
                 </Routes>
             </main>
             <Footer/>

--- a/frontend/src/components/ProfileComponent.tsx
+++ b/frontend/src/components/ProfileComponent.tsx
@@ -20,7 +20,11 @@ export default function UserProfile({username}: UserProfileProps) {
             }
 setLoading(true);  // Reset loading when username changes
             try {
-                const response = await axios.get<User>('/api/user/' + username);
+                const response = await axios.get<User>('/api/user/', {
+                    params: {
+                        name: username
+                    }
+                });
                 setUser(response.data);
                 setError(null); // ✅ Clear previous errors on success
             } catch (error) {

--- a/frontend/src/components/WorkOfArtComponent.tsx
+++ b/frontend/src/components/WorkOfArtComponent.tsx
@@ -1,0 +1,112 @@
+import {useEffect, useState} from "react";
+import {WorkOfArt} from "../types.tsx";
+import axios from "axios";
+
+type WorkOfArtComponentProps = {
+    workOfArtId?: string;
+};
+
+function transformImageUrl(url: string): string {
+    const parts = url.split('/upload/');
+    if (parts.length !== 2) {
+        throw new Error('Invalid URL format');
+    }
+    return `${parts[0]}/upload/c_scale,w_500/q_auto/f_auto/${parts[1]}`;
+}
+
+export default function WorkOfArtComponent({workOfArtId}: WorkOfArtComponentProps) {
+    const [workOfArt, setWorkOfArt] = useState<WorkOfArt | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        async function fetchWorkOfArt(workOfArtId: string | undefined) {
+            if (!workOfArtId) {
+                setError('Work of art ID is required');
+                setLoading(false);
+                return;
+            }
+            setLoading(true);  // Reset loading when workOfArtId changes
+            try {
+                const response = await axios.get<WorkOfArt>('/api/woa/' + workOfArtId);
+                setWorkOfArt(response.data);
+                setError(null); // ✅ Clear previous errors on success
+            } catch (error) {
+                setError(error instanceof Error ? error.message : String(error));
+            } finally {
+                setLoading(false);
+            }
+        }
+
+        void fetchWorkOfArt(workOfArtId);
+    }, [workOfArtId]);
+
+    if (loading) return <div className="mt-24 text-center">Loading...</div>;
+    if (error) return <div
+        className="mt-24 text-center text-red-500">Error: {error}</div>;
+    if (!workOfArt) return <div className="mt-24 text-center">No work of art data
+        available</div>;
+
+    return (
+        <div className="container mx-auto px-4 mt-24">
+            <div className="max-w-2xl mx-auto space-y-6">
+                {/* User and Medium Section */}
+                <div
+                    className="flex justify-between bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                    <div>
+                        <h2 className="text-2xl font-semibold text-gray-800">
+                            <a href={`/user/${workOfArt.user}`}>{workOfArt.user}</a>
+                        </h2>
+                    </div>
+                    <div>
+                        <p className="text-gray-600">{workOfArt.medium}</p>
+                    </div>
+                </div>
+
+                {/* Image Section */}
+                <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                    <img src={transformImageUrl(workOfArt.imageUrl)}
+                         alt={workOfArt.title} className="w-full rounded-lg"/>
+                </div>
+
+                {/* Title Section */}
+                <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                    <h3 className="text-xl font-semibold text-gray-800 mb-4">{workOfArt.title}</h3>
+                </div>
+
+                {/* Description Section */}
+                <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                    <h3 className="text-xl font-semibold text-gray-800 mb-4">Description</h3>
+                    <p className="text-gray-600">
+                        {workOfArt.description || 'No description yet 🌳'}
+                    </p>
+                </div>
+
+                {/* Materials Section */}
+                {workOfArt.materials && workOfArt.materials.length > 0 && (
+                    <div
+                        className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                        <h3 className="text-xl font-semibold text-gray-800 mb-4">Materials</h3>
+                        {workOfArt.materials.map((material, index) => (
+                            <p key={index} className="text-gray-600">
+                                {/* TODO: Different material description depending on what's available */}
+                                {material.type} {material.identifier} - {material.name} by {material.brand} ({material.line})
+                            </p>
+                        ))}
+                    </div>
+                )}
+
+                {/* Challenge Section */}
+                {workOfArt.challengeId && (
+                    <div
+                        className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                        <h3 className="text-xl font-semibold text-gray-800 mb-4">Challenge</h3>
+                        <p className="text-gray-600">
+                            See challenge: {workOfArt.challengeId}
+                        </p>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/WorkOfArtComponent.tsx
+++ b/frontend/src/components/WorkOfArtComponent.tsx
@@ -14,6 +14,14 @@ function transformImageUrl(url: string): string {
     return `${parts[0]}/upload/c_scale,w_500/q_auto/f_auto/${parts[1]}`;
 }
 
+function formatDate(dateString: string): string {
+    const date = new Date(dateString);
+    const day = String(date.getDate()).padStart(2, '0');
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const year = date.getFullYear();
+    return `${day}/${month}/${year}`;
+}
+
 function useUser(userId: string | undefined) {
     const [user, setUser] = useState<User | null>(null);
     const [loading, setLoading] = useState(true);
@@ -103,8 +111,16 @@ export default function WorkOfArtComponent({workOfArtId}: WorkOfArtComponentProp
                 </div>
 
                 {/* Title Section */}
-                <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
-                    <h3 className="text-xl font-semibold text-gray-800 mb-4">{workOfArt.title}</h3>
+                <div
+                    className="flex justify-between bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                    <div>
+                        <h3 className="text-2xl font-semibold text-gray-800">
+                            {workOfArt.title}
+                        </h3>
+                    </div>
+                    <div>
+                        <p className="text-gray-600">{formatDate(workOfArt.createdAt)}</p>
+                    </div>
                 </div>
 
                 {/* Description Section */}

--- a/frontend/src/pages/WorkOfArtPage.tsx
+++ b/frontend/src/pages/WorkOfArtPage.tsx
@@ -6,7 +6,7 @@ export default function WorkOfArtPage() {
     const {workOfArtId} = useParams<{ workOfArtId?: string }>();
 
     return (
-        <div>
+        <div className="pb-24">
             <WorkOfArt workOfArtId={workOfArtId}/>
         </div>
     );

--- a/frontend/src/pages/WorkOfArtPage.tsx
+++ b/frontend/src/pages/WorkOfArtPage.tsx
@@ -1,0 +1,13 @@
+import {useParams} from "react-router-dom";
+import WorkOfArt from "../components/WorkOfArtComponent.tsx";
+
+export default function WorkOfArtPage() {
+
+    const {workOfArtId} = useParams<{ workOfArtId?: string }>();
+
+    return (
+        <div>
+            <WorkOfArt workOfArtId={workOfArtId}/>
+        </div>
+    );
+}

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -40,4 +40,5 @@ export type WorkOfArt = {
     imageUrl: string;
     medium: Medium;
     materials: Material[] | null;
+    createdAt: string;
 }

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -21,3 +21,23 @@ export type User = {
     imageUrl: string | null;
     mediums: Medium[];
 }
+
+export type Material = {
+    name: string;
+    identifier: string | null;
+    brand: string | null;
+    line: string | null;
+    type: string | null;
+    medium: Medium | null;
+}
+
+export type WorkOfArt = {
+    id: string;
+    user: string;
+    challengeId: string | null;
+    title: string;
+    description: string | null;
+    imageUrl: string;
+    medium: Medium;
+    materials: Material[] | null;
+}


### PR DESCRIPTION
Closes: #8 

With this PR, a detail view for the work of art is provided.

New on the backend:
- GET endpoint for the single work of art, by id
- the GET endpoint for the user profile uses request parameters instead of path variables, and can accept either id or name
- exception handling
- logging defaulting to info

New on the frontend:
- view for the single work of art - it makes two API calls, one for the work of art and one for the user to display the name, to keep the controllers resource-based
- refactor of the user profile page to pass the user name as request parameter instead of path variable

 
![image](https://github.com/user-attachments/assets/925ac94c-7d18-475e-8642-7b4d635b3e85)

