### PR TITLE
feat: Basic newsfeed that gets all posts

### DIFF
--- a/backend/src/main/kotlin/de/neuefische/backend/common/Medium.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/common/Medium.kt
@@ -15,3 +15,7 @@ enum class Medium (val lowercase: String){
     PENCILS("pencils"),
     WATERCOLORS("watercolors"),
 }
+
+fun String.toMedium(): Medium? {
+    return Medium.entries.find { it.name.equals(this, ignoreCase = true) }
+}

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArt.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArt.kt
@@ -12,6 +12,7 @@ data class WorkOfArt(
     val id: BsonObjectId = BsonObjectId(),
     val user: BsonObjectId,
     val challengeId: BsonObjectId? = null,
+    val userName: String,
     val title: String,
     val description: String? = null,
     val imageUrl: String,

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtController.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtController.kt
@@ -1,10 +1,9 @@
 package de.neuefische.backend.woa
 
+import de.neuefische.backend.common.Medium
+import de.neuefische.backend.common.toMedium
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/woa")
@@ -19,5 +18,18 @@ class WorkOfArtController(private val workOfArtService: WorkOfArtService) {
         } else {
             ResponseEntity.notFound().build()
         }
+    }
+
+    @GetMapping()
+    fun getAllWorksOfArt(
+        @RequestParam(required = false) mediums: List<String>?,
+    ): ResponseEntity<List<WorkOfArtShortResponse>> {
+        if (mediums.isNullOrEmpty()) {
+            val worksOfArt = workOfArtService.getAllWorksOfArt()
+            return ResponseEntity.ok(worksOfArt)
+        }
+        val foundMediums: List<Medium> = mediums.mapNotNull { it.toMedium()}
+        val worksOfArt = workOfArtService.getAllWorksOfArt(foundMediums)
+        return ResponseEntity.ok(worksOfArt)
     }
 }

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtRepo.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtRepo.kt
@@ -1,6 +1,8 @@
 package de.neuefische.backend.woa
 
+import de.neuefische.backend.common.Medium
 import org.springframework.data.mongodb.repository.MongoRepository
 
 interface WorkOfArtRepo : MongoRepository<WorkOfArt, String> {
+    fun findAllByMediumIn(mediums: List<Medium>): List<WorkOfArt>
 }

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtResponse.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtResponse.kt
@@ -3,6 +3,7 @@ package de.neuefische.backend.woa
 data class WorkOfArtResponse(
     val id: String,
     val user: String,
+    val userName: String,
     val challengeId: String? = null,
     val title: String,
     val description: String? = null,

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtService.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtService.kt
@@ -13,6 +13,7 @@ class WorkOfArtService(private val workOfArtRepo: WorkOfArtRepo) {
             WorkOfArtResponse(
                 id = workOfArt.id.value.toString(),
                 user = workOfArt.user.value.toString(),
+                userName = workOfArt.userName,
                 challengeId = workOfArt.challengeId?.value?.toString(),
                 title = workOfArt.title,
                 description = workOfArt.description,
@@ -45,6 +46,7 @@ class WorkOfArtService(private val workOfArtRepo: WorkOfArtRepo) {
             WorkOfArtShortResponse(
                 id = workOfArt.id.value.toString(),
                 user = workOfArt.user.value.toString(),
+                userName = workOfArt.userName,
                 title = workOfArt.title,
                 imageUrl = workOfArt.imageUrl,
                 medium = workOfArt.medium.lowercase,

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtService.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtService.kt
@@ -1,5 +1,6 @@
 package de.neuefische.backend.woa
 
+import de.neuefische.backend.common.Medium
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
@@ -27,6 +28,26 @@ class WorkOfArtService(private val workOfArtRepo: WorkOfArtRepo) {
                         medium = material.medium?.lowercase,
                     )
                 } ?: emptyList(),
+                createdAt = workOfArt.createdAt.toString(),
+            )
+        }
+    }
+
+    fun getAllWorksOfArt(mediums: List<Medium>? = null): List<WorkOfArtShortResponse> {
+        val worksOfArt = if (mediums.isNullOrEmpty()) {
+            workOfArtRepo.findAll()
+        } else {
+            workOfArtRepo.findAllByMediumIn(mediums)
+        }
+        return worksOfArt
+            .sortedByDescending { it.createdAt }
+            .map { workOfArt ->
+            WorkOfArtShortResponse(
+                id = workOfArt.id.value.toString(),
+                user = workOfArt.user.value.toString(),
+                title = workOfArt.title,
+                imageUrl = workOfArt.imageUrl,
+                medium = workOfArt.medium.lowercase,
                 createdAt = workOfArt.createdAt.toString(),
             )
         }

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtShortResponse.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtShortResponse.kt
@@ -3,6 +3,7 @@ package de.neuefische.backend.woa
 data class WorkOfArtShortResponse(
     val id: String,
     val user: String,
+    val userName: String,
     val title: String,
     val imageUrl: String,
     val medium: String,

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtShortResponse.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtShortResponse.kt
@@ -1,0 +1,10 @@
+package de.neuefische.backend.woa
+
+data class WorkOfArtShortResponse(
+    val id: String,
+    val user: String,
+    val title: String,
+    val imageUrl: String,
+    val medium: String,
+    val createdAt: String,
+)

--- a/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtControllerTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtControllerTest.kt
@@ -53,6 +53,7 @@ class WorkOfArtControllerTest {
         id = BsonObjectId(),
         user = BsonObjectId(),
         challengeId = BsonObjectId(),
+        userName = "max_mustermann",
         title = "Yellow Sunset",
         description = "a yellow sunset",
         imageUrl = "https://example.com/yellow-sunset.jpg",
@@ -66,6 +67,7 @@ class WorkOfArtControllerTest {
     private val blueDawn = WorkOfArt(
         id = BsonObjectId(),
         user = BsonObjectId(),
+        userName = "mario_rossi",
         title = "Blue Dawn",
         imageUrl = "https://example.com/blue-dawn.jpg",
         medium = Medium.GOUACHE,
@@ -75,6 +77,7 @@ class WorkOfArtControllerTest {
         id = BsonObjectId(),
         user = BsonObjectId(),
         challengeId = BsonObjectId(),
+        userName = "jane_snow",
         title = "Red Midday",
         description = "a red midday",
         imageUrl = "https://example.com/red-midday.jpg",
@@ -100,6 +103,7 @@ class WorkOfArtControllerTest {
             .andExpect(jsonPath("$.id").value(yellowSunset.id.value.toString()))
             .andExpect(jsonPath("$.user").value(yellowSunset.user.value.toString()))
             .andExpect(jsonPath("$.challengeId").value(yellowSunset.challengeId?.value.toString()))
+            .andExpect(jsonPath("$.userName").value("max_mustermann"))
             .andExpect(jsonPath("$.title").value("Yellow Sunset"))
             .andExpect(jsonPath("$.description").value("a yellow sunset"))
             .andExpect(jsonPath("$.imageUrl").value("https://example.com/yellow-sunset.jpg"))
@@ -148,6 +152,7 @@ class WorkOfArtControllerTest {
         result.andExpect(status().isOk)
             .andExpect(jsonPath("$.id").value(blueDawn.id.value.toString()))
             .andExpect(jsonPath("$.user").value(blueDawn.user.value.toString()))
+            .andExpect(jsonPath("$.userName").value("mario_rossi"))
             .andExpect(jsonPath("$.challengeId").doesNotExist())
             .andExpect(jsonPath("$.title").value("Blue Dawn"))
             .andExpect(jsonPath("$.description").doesNotExist())
@@ -173,18 +178,21 @@ class WorkOfArtControllerTest {
         result.andExpect(status().isOk)
             .andExpect(jsonPath("$[0].id").value(redMidday.id.value.toString()))
             .andExpect(jsonPath("$[0].user").value(redMidday.user.value.toString()))
+            .andExpect(jsonPath("$[0].userName").value("jane_snow"))
             .andExpect(jsonPath("$[0].title").value("Red Midday"))
             .andExpect(jsonPath("$[0].imageUrl").value("https://example.com/red-midday.jpg"))
             .andExpect(jsonPath("$[0].medium").value("watercolors"))
             .andExpect(jsonPath("$[0].createdAt").value(redMidday.createdAt.toString()))
             .andExpect(jsonPath("$[1].id").value(blueDawn.id.value.toString()))
             .andExpect(jsonPath("$[1].user").value(blueDawn.user.value.toString()))
+            .andExpect(jsonPath("$[1].userName").value("mario_rossi"))
             .andExpect(jsonPath("$[1].title").value("Blue Dawn"))
             .andExpect(jsonPath("$[1].imageUrl").value("https://example.com/blue-dawn.jpg"))
             .andExpect(jsonPath("$[1].medium").value("gouache"))
             .andExpect(jsonPath("$[1].createdAt").value(blueDawn.createdAt.toString()))
             .andExpect(jsonPath("$[2].id").value(yellowSunset.id.value.toString()))
             .andExpect(jsonPath("$[2].user").value(yellowSunset.user.value.toString()))
+            .andExpect(jsonPath("$[2].userName").value("max_mustermann"))
             .andExpect(jsonPath("$[2].title").value("Yellow Sunset"))
             .andExpect(jsonPath("$[2].imageUrl").value("https://example.com/yellow-sunset.jpg"))
             .andExpect(jsonPath("$[2].medium").value("watercolors"))
@@ -206,12 +214,14 @@ class WorkOfArtControllerTest {
         result.andExpect(status().isOk)
             .andExpect(jsonPath("$[0].id").value(redMidday.id.value.toString()))
             .andExpect(jsonPath("$[0].user").value(redMidday.user.value.toString()))
+            .andExpect(jsonPath("$[0].userName").value("jane_snow"))
             .andExpect(jsonPath("$[0].title").value("Red Midday"))
             .andExpect(jsonPath("$[0].imageUrl").value("https://example.com/red-midday.jpg"))
             .andExpect(jsonPath("$[0].medium").value("watercolors"))
             .andExpect(jsonPath("$[0].createdAt").value(redMidday.createdAt.toString()))
             .andExpect(jsonPath("$[1].id").value(yellowSunset.id.value.toString()))
             .andExpect(jsonPath("$[1].user").value(yellowSunset.user.value.toString()))
+            .andExpect(jsonPath("$[1].userName").value("max_mustermann"))
             .andExpect(jsonPath("$[1].title").value("Yellow Sunset"))
             .andExpect(jsonPath("$[1].imageUrl").value("https://example.com/yellow-sunset.jpg"))
             .andExpect(jsonPath("$[1].medium").value("watercolors"))

--- a/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtControllerTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtControllerTest.kt
@@ -24,54 +24,85 @@ class WorkOfArtControllerTest {
     @MockkBean
     private lateinit var workOfArtRepo: WorkOfArtRepo
 
+    // Reusable test data
+    private val yellowCadmium24 = Material(
+        name = "Yellow Cadmium 24",
+        identifier = "24",
+        brand = "Schmincke",
+        line = "Horadam",
+        type = "Half Pan",
+        medium = Medium.WATERCOLORS,
+    )
+    private val scarletRed12 = Material(
+        name = "Scarlet Red",
+        identifier = "12",
+        brand = "Schmincke",
+        line = "Akademie",
+        type = "Tube",
+        medium = Medium.WATERCOLORS,
+    )
+    private val paintbrush = Material(
+        // This one has some missing fields
+        name = "Round Brush",
+        brand = "Da Vinci",
+        line = "Maestro",
+        type = "Paintbrush",
+    )
+
+    private val yellowSunset = WorkOfArt(
+        id = BsonObjectId(),
+        user = BsonObjectId(),
+        challengeId = BsonObjectId(),
+        title = "Yellow Sunset",
+        description = "a yellow sunset",
+        imageUrl = "https://example.com/yellow-sunset.jpg",
+        medium = Medium.WATERCOLORS,
+        materials = listOf(
+            yellowCadmium24,
+            paintbrush,
+        ),
+    )
+
+    private val blueDawn = WorkOfArt(
+        id = BsonObjectId(),
+        user = BsonObjectId(),
+        title = "Blue Dawn",
+        imageUrl = "https://example.com/blue-dawn.jpg",
+        medium = Medium.GOUACHE,
+    )
+
+    private val redMidday = WorkOfArt(
+        id = BsonObjectId(),
+        user = BsonObjectId(),
+        challengeId = BsonObjectId(),
+        title = "Red Midday",
+        description = "a red midday",
+        imageUrl = "https://example.com/red-midday.jpg",
+        medium = Medium.WATERCOLORS,
+        materials = listOf(
+            scarletRed12,
+            paintbrush
+        ),
+    )
+
     // GET /api/woa/{id}
     @Test
     fun getWorkOfArtById() {
 
         // Given
-        val workOfArtId = BsonObjectId()
-        val workOfArtUserId = BsonObjectId()
-        val workOfArtChallengeId = BsonObjectId()
-
-        val workOfArt = WorkOfArt(
-            id = workOfArtId,
-            user = workOfArtUserId,
-            challengeId = workOfArtChallengeId,
-            title = "test-title",
-            description = "test-description",
-            imageUrl = "test-image-url",
-            medium = Medium.WATERCOLORS,
-            materials = listOf(
-                Material(
-                    name = "Yellow Cadmium 24",
-                    identifier = "24",
-                    brand = "Schmincke",
-                    line = "Horadam",
-                    type = "Half Pan",
-                    medium = Medium.WATERCOLORS,
-                ),
-                Material(
-                    name = "Round Brush",
-                    brand = "Da Vinci",
-                    line = "Maestro",
-                    type = "Paintbrush",
-                ),
-            ),
-        )
-
-        every { workOfArtRepo.findByIdOrNull(workOfArtId.value.toString()) } returns workOfArt
+        every { workOfArtRepo.findByIdOrNull(yellowSunset.id.value.toString()) } returns yellowSunset
 
         // When
-        val result = mockMvc.perform(get("/api/woa/${workOfArtId.value}"))
+        val result = mockMvc.perform(get("/api/woa/${yellowSunset.id.value}"))
 
         // Then
         result.andExpect(status().isOk)
-            .andExpect(jsonPath("$.id").value(workOfArtId.value.toString()))
-            .andExpect(jsonPath("$.user").value(workOfArtUserId.value.toString()))
-            .andExpect(jsonPath("$.challengeId").value(workOfArtChallengeId.value.toString()))
-            .andExpect(jsonPath("$.title").value("test-title"))
-            .andExpect(jsonPath("$.description").value("test-description"))
-            .andExpect(jsonPath("$.imageUrl").value("test-image-url"))
+            .andExpect(jsonPath("$.id").value(yellowSunset.id.value.toString()))
+            .andExpect(jsonPath("$.user").value(yellowSunset.user.value.toString()))
+            .andExpect(jsonPath("$.challengeId").value(yellowSunset.challengeId?.value.toString()))
+            .andExpect(jsonPath("$.title").value("Yellow Sunset"))
+            .andExpect(jsonPath("$.description").value("a yellow sunset"))
+            .andExpect(jsonPath("$.imageUrl").value("https://example.com/yellow-sunset.jpg"))
             .andExpect(jsonPath("$.medium").value("watercolors"))
             .andExpect(jsonPath("$.materials").isArray)
             .andExpect(jsonPath("$.materials[0].name").value("Yellow Cadmium 24"))
@@ -86,7 +117,7 @@ class WorkOfArtControllerTest {
             .andExpect(jsonPath("$.materials[1].line").value("Maestro"))
             .andExpect(jsonPath("$.materials[1].type").value("Paintbrush"))
             .andExpect(jsonPath("$.materials[1].medium").doesNotExist())
-            .andExpect(jsonPath("$.createdAt").value(workOfArt.createdAt.toString()))
+            .andExpect(jsonPath("$.createdAt").value(yellowSunset.createdAt.toString()))
     }
 
     @Test
@@ -108,32 +139,82 @@ class WorkOfArtControllerTest {
     fun getWorkOfArtByIdWithOnlyRequiredFields() {
 
         // Given
-        val workOfArtId = BsonObjectId()
-        val workOfArtUserId = BsonObjectId()
-
-        val workOfArt = WorkOfArt(
-            id = workOfArtId,
-            user = workOfArtUserId,
-            title = "test-title",
-            imageUrl = "test-image-url",
-            medium = Medium.GOUACHE,
-        )
-
-        every { workOfArtRepo.findByIdOrNull(workOfArtId.value.toString()) } returns workOfArt
+        every { workOfArtRepo.findByIdOrNull(blueDawn.id.value.toString()) } returns blueDawn
 
         // When
-        val result = mockMvc.perform(get("/api/woa/${workOfArtId.value}"))
+        val result = mockMvc.perform(get("/api/woa/${blueDawn.id.value}"))
 
         // Then
         result.andExpect(status().isOk)
-            .andExpect(jsonPath("$.id").value(workOfArtId.value.toString()))
-            .andExpect(jsonPath("$.user").value(workOfArtUserId.value.toString()))
+            .andExpect(jsonPath("$.id").value(blueDawn.id.value.toString()))
+            .andExpect(jsonPath("$.user").value(blueDawn.user.value.toString()))
             .andExpect(jsonPath("$.challengeId").doesNotExist())
-            .andExpect(jsonPath("$.title").value("test-title"))
+            .andExpect(jsonPath("$.title").value("Blue Dawn"))
             .andExpect(jsonPath("$.description").doesNotExist())
-            .andExpect(jsonPath("$.imageUrl").value("test-image-url"))
+            .andExpect(jsonPath("$.imageUrl").value("https://example.com/blue-dawn.jpg"))
             .andExpect(jsonPath("$.medium").value("gouache"))
             .andExpect(jsonPath("$.materials").isEmpty())
-            .andExpect(jsonPath("$.createdAt").value(workOfArt.createdAt.toString()))
+            .andExpect(jsonPath("$.createdAt").value(blueDawn.createdAt.toString()))
+    }
+
+    @Test
+    fun getAllWorksOfArtNoFilters() {
+        // Given
+        every { workOfArtRepo.findAll() } returns listOf(
+            redMidday,
+            blueDawn,
+            yellowSunset
+        )
+
+        // When
+        val result = mockMvc.perform(get("/api/woa"))
+
+        // Then
+        result.andExpect(status().isOk)
+            .andExpect(jsonPath("$[0].id").value(redMidday.id.value.toString()))
+            .andExpect(jsonPath("$[0].user").value(redMidday.user.value.toString()))
+            .andExpect(jsonPath("$[0].title").value("Red Midday"))
+            .andExpect(jsonPath("$[0].imageUrl").value("https://example.com/red-midday.jpg"))
+            .andExpect(jsonPath("$[0].medium").value("watercolors"))
+            .andExpect(jsonPath("$[0].createdAt").value(redMidday.createdAt.toString()))
+            .andExpect(jsonPath("$[1].id").value(blueDawn.id.value.toString()))
+            .andExpect(jsonPath("$[1].user").value(blueDawn.user.value.toString()))
+            .andExpect(jsonPath("$[1].title").value("Blue Dawn"))
+            .andExpect(jsonPath("$[1].imageUrl").value("https://example.com/blue-dawn.jpg"))
+            .andExpect(jsonPath("$[1].medium").value("gouache"))
+            .andExpect(jsonPath("$[1].createdAt").value(blueDawn.createdAt.toString()))
+            .andExpect(jsonPath("$[2].id").value(yellowSunset.id.value.toString()))
+            .andExpect(jsonPath("$[2].user").value(yellowSunset.user.value.toString()))
+            .andExpect(jsonPath("$[2].title").value("Yellow Sunset"))
+            .andExpect(jsonPath("$[2].imageUrl").value("https://example.com/yellow-sunset.jpg"))
+            .andExpect(jsonPath("$[2].medium").value("watercolors"))
+            .andExpect(jsonPath("$[2].createdAt").value(yellowSunset.createdAt.toString()))
+    }
+
+    @Test
+    fun getAllWorksOfArtWithMediumsFilter() {
+        // Given
+        every { workOfArtRepo.findAllByMediumIn(listOf(Medium.WATERCOLORS)) } returns listOf(
+            redMidday,
+            yellowSunset
+        )
+
+        // When
+        val result = mockMvc.perform(get("/api/woa?mediums=watercolors"))
+
+        // Then
+        result.andExpect(status().isOk)
+            .andExpect(jsonPath("$[0].id").value(redMidday.id.value.toString()))
+            .andExpect(jsonPath("$[0].user").value(redMidday.user.value.toString()))
+            .andExpect(jsonPath("$[0].title").value("Red Midday"))
+            .andExpect(jsonPath("$[0].imageUrl").value("https://example.com/red-midday.jpg"))
+            .andExpect(jsonPath("$[0].medium").value("watercolors"))
+            .andExpect(jsonPath("$[0].createdAt").value(redMidday.createdAt.toString()))
+            .andExpect(jsonPath("$[1].id").value(yellowSunset.id.value.toString()))
+            .andExpect(jsonPath("$[1].user").value(yellowSunset.user.value.toString()))
+            .andExpect(jsonPath("$[1].title").value("Yellow Sunset"))
+            .andExpect(jsonPath("$[1].imageUrl").value("https://example.com/yellow-sunset.jpg"))
+            .andExpect(jsonPath("$[1].medium").value("watercolors"))
+            .andExpect(jsonPath("$[1].createdAt").value(yellowSunset.createdAt.toString()))
     }
 }

--- a/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
@@ -13,41 +13,50 @@ class WorkOfArtServiceTest {
     private val workOfArtRepo = mockk<WorkOfArtRepo>()
     private val workOfArtService = WorkOfArtService(workOfArtRepo)
 
+    // Reusable test data
+    private val yellowCadmium24 = Material(
+        name = "Yellow Cadmium 24",
+        identifier = "24",
+        brand = "Schmincke",
+        line = "Horadam",
+        type = "Half Pan",
+        medium = Medium.WATERCOLORS,
+    )
+    private val paintbrush = Material(
+        // This one has some missing fields
+        name = "Round Brush",
+        brand = "Da Vinci",
+        line = "Maestro",
+        type = "Paintbrush",
+    )
+
+    private val yellowSunset = WorkOfArt(
+        id = BsonObjectId(),
+        user = BsonObjectId(),
+        challengeId = BsonObjectId(),
+        title = "test-title",
+        description = "test-description",
+        imageUrl = "test-image-url",
+        medium = Medium.WATERCOLORS,
+        materials = listOf(yellowCadmium24, paintbrush),
+    )
+
+    private val blueDawn = WorkOfArt(
+        id = BsonObjectId(),
+        user = BsonObjectId(),
+        title = "test-title",
+        imageUrl = "test-image-url",
+        medium = Medium.PAN_PASTELS,
+    )
+
     @Test
     fun getWorkOfArtById() {
 
         // Given
-        val yellowCadmium24 = Material(
-            name = "Yellow Cadmium 24",
-            identifier = "24",
-            brand = "Schmincke",
-            line = "Horadam",
-            type = "Half Pan",
-            medium = Medium.WATERCOLORS,
-        )
-        val paintbrush = Material(
-            // This one has some missing fields
-            name = "Round Brush",
-            brand = "Da Vinci",
-            line = "Maestro",
-            type = "Paintbrush",
-        )
-
-        val workOfArt = WorkOfArt(
-            id = BsonObjectId(),
-            user = BsonObjectId(),
-            challengeId = BsonObjectId(),
-            title = "test-title",
-            description = "test-description",
-            imageUrl = "test-image-url",
-            medium = Medium.WATERCOLORS,
-            materials = listOf(yellowCadmium24, paintbrush),
-        )
-
         val expectedResponse = WorkOfArtResponse(
-            id = workOfArt.id.value.toString(),
-            user = workOfArt.user.value.toString(),
-            challengeId = workOfArt.challengeId?.value.toString(),
+            id = yellowSunset.id.value.toString(),
+            user = yellowSunset.user.value.toString(),
+            challengeId = yellowSunset.challengeId?.value.toString(),
             title = "test-title",
             description = "test-description",
             imageUrl = "test-image-url",
@@ -68,13 +77,13 @@ class WorkOfArtServiceTest {
                     type = "Paintbrush",
                 )
             ),
-            createdAt = workOfArt.createdAt.toString(),
+            createdAt = yellowSunset.createdAt.toString(),
         )
 
-        every { workOfArtRepo.findByIdOrNull(workOfArt.id.value.toString()) } returns workOfArt
+        every { workOfArtRepo.findByIdOrNull(yellowSunset.id.value.toString()) } returns yellowSunset
 
         // When
-        val result = workOfArtService.getWorkOfArtById(workOfArt.id.value.toString())
+        val result = workOfArtService.getWorkOfArtById(yellowSunset.id.value.toString())
 
         // Then
         assertEquals(expectedResponse, result)
@@ -84,27 +93,19 @@ class WorkOfArtServiceTest {
     fun getWorkOfArtByIdWithOnlyRequiredFields() {
 
         // Given
-        val workOfArt = WorkOfArt(
-            id = BsonObjectId(),
-            user = BsonObjectId(),
-            title = "test-title",
-            imageUrl = "test-image-url",
-            medium = Medium.PAN_PASTELS,
-        )
-
         val expectedResponse = WorkOfArtResponse(
-            id = workOfArt.id.value.toString(),
-            user = workOfArt.user.value.toString(),
+            id = blueDawn.id.value.toString(),
+            user = blueDawn.user.value.toString(),
             title = "test-title",
             imageUrl = "test-image-url",
             medium = "pan pastels",
-            createdAt = workOfArt.createdAt.toString(),
+            createdAt = blueDawn.createdAt.toString(),
         )
 
-        every { workOfArtRepo.findByIdOrNull(workOfArt.id.value.toString()) } returns workOfArt
+        every { workOfArtRepo.findByIdOrNull(blueDawn.id.value.toString()) } returns blueDawn
 
         // When
-        val result = workOfArtService.getWorkOfArtById(workOfArt.id.value.toString())
+        val result = workOfArtService.getWorkOfArtById(blueDawn.id.value.toString())
 
         // Then
         assertEquals(expectedResponse, result)

--- a/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
@@ -42,6 +42,7 @@ class WorkOfArtServiceTest {
         id = BsonObjectId(),
         user = BsonObjectId(),
         challengeId = BsonObjectId(),
+        userName = "max_mustermann",
         title = "Yellow Sunset",
         description = "a yellow sunset",
         imageUrl = "https://example.com/yellow-sunset.jpg",
@@ -52,6 +53,7 @@ class WorkOfArtServiceTest {
     private val blueDawn = WorkOfArt(
         id = BsonObjectId(),
         user = BsonObjectId(),
+        userName = "mario_rossi",
         title = "Blue Dawn",
         imageUrl = "https://example.com/blue-dawn.jpg",
         medium = Medium.PAN_PASTELS,
@@ -61,6 +63,7 @@ class WorkOfArtServiceTest {
         id = BsonObjectId(),
         user = BsonObjectId(),
         challengeId = BsonObjectId(),
+        userName = "jane_snow",
         title = "Red Midday",
         description = "a red midday",
         imageUrl = "https://example.com/red-midday.jpg",
@@ -76,6 +79,7 @@ class WorkOfArtServiceTest {
             id = yellowSunset.id.value.toString(),
             user = yellowSunset.user.value.toString(),
             challengeId = yellowSunset.challengeId?.value.toString(),
+            userName = "max_mustermann",
             title = "Yellow Sunset",
             description = "a yellow sunset",
             imageUrl = "https://example.com/yellow-sunset.jpg",
@@ -115,6 +119,7 @@ class WorkOfArtServiceTest {
         val expectedResponse = WorkOfArtResponse(
             id = blueDawn.id.value.toString(),
             user = blueDawn.user.value.toString(),
+            userName = "mario_rossi",
             title = "Blue Dawn",
             imageUrl = "https://example.com/blue-dawn.jpg",
             medium = "pan pastels",
@@ -137,6 +142,7 @@ class WorkOfArtServiceTest {
             WorkOfArtShortResponse(
                 id = redMidday.id.value.toString(),
                 user = redMidday.user.value.toString(),
+                userName = "jane_snow",
                 title = "Red Midday",
                 imageUrl = "https://example.com/red-midday.jpg",
                 medium = "watercolors",
@@ -145,6 +151,7 @@ class WorkOfArtServiceTest {
             WorkOfArtShortResponse(
                 id = blueDawn.id.value.toString(),
                 user = blueDawn.user.value.toString(),
+                userName = "mario_rossi",
                 title = "Blue Dawn",
                 imageUrl = "https://example.com/blue-dawn.jpg",
                 medium = "pan pastels",
@@ -153,6 +160,7 @@ class WorkOfArtServiceTest {
             WorkOfArtShortResponse(
                 id = yellowSunset.id.value.toString(),
                 user = yellowSunset.user.value.toString(),
+                userName = "max_mustermann",
                 title = "Yellow Sunset",
                 imageUrl = "https://example.com/yellow-sunset.jpg",
                 medium = "watercolors",
@@ -177,6 +185,7 @@ class WorkOfArtServiceTest {
             WorkOfArtShortResponse(
                 id = redMidday.id.value.toString(),
                 user = redMidday.user.value.toString(),
+                userName = "jane_snow",
                 title = "Red Midday",
                 imageUrl = "https://example.com/red-midday.jpg",
                 medium = "watercolors",
@@ -185,6 +194,7 @@ class WorkOfArtServiceTest {
             WorkOfArtShortResponse(
                 id = yellowSunset.id.value.toString(),
                 user = yellowSunset.user.value.toString(),
+                userName = "max_mustermann",
                 title = "Yellow Sunset",
                 imageUrl = "https://example.com/yellow-sunset.jpg",
                 medium = "watercolors",

--- a/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
@@ -22,6 +22,14 @@ class WorkOfArtServiceTest {
         type = "Half Pan",
         medium = Medium.WATERCOLORS,
     )
+    private val scarletRed12 = Material(
+        name = "Scarlet Red",
+        identifier = "12",
+        brand = "Schmincke",
+        line = "Akademie",
+        type = "Tube",
+        medium = Medium.WATERCOLORS,
+    )
     private val paintbrush = Material(
         // This one has some missing fields
         name = "Round Brush",
@@ -34,9 +42,9 @@ class WorkOfArtServiceTest {
         id = BsonObjectId(),
         user = BsonObjectId(),
         challengeId = BsonObjectId(),
-        title = "test-title",
-        description = "test-description",
-        imageUrl = "test-image-url",
+        title = "Yellow Sunset",
+        description = "a yellow sunset",
+        imageUrl = "https://example.com/yellow-sunset.jpg",
         medium = Medium.WATERCOLORS,
         materials = listOf(yellowCadmium24, paintbrush),
     )
@@ -44,9 +52,20 @@ class WorkOfArtServiceTest {
     private val blueDawn = WorkOfArt(
         id = BsonObjectId(),
         user = BsonObjectId(),
-        title = "test-title",
-        imageUrl = "test-image-url",
+        title = "Blue Dawn",
+        imageUrl = "https://example.com/blue-dawn.jpg",
         medium = Medium.PAN_PASTELS,
+    )
+
+    private val redMidday = WorkOfArt(
+        id = BsonObjectId(),
+        user = BsonObjectId(),
+        challengeId = BsonObjectId(),
+        title = "Red Midday",
+        description = "a red midday",
+        imageUrl = "https://example.com/red-midday.jpg",
+        medium = Medium.WATERCOLORS,
+        materials = listOf(scarletRed12, paintbrush),
     )
 
     @Test
@@ -57,9 +76,9 @@ class WorkOfArtServiceTest {
             id = yellowSunset.id.value.toString(),
             user = yellowSunset.user.value.toString(),
             challengeId = yellowSunset.challengeId?.value.toString(),
-            title = "test-title",
-            description = "test-description",
-            imageUrl = "test-image-url",
+            title = "Yellow Sunset",
+            description = "a yellow sunset",
+            imageUrl = "https://example.com/yellow-sunset.jpg",
             medium = "watercolors",
             materials = listOf(
                 MaterialResponse(
@@ -96,8 +115,8 @@ class WorkOfArtServiceTest {
         val expectedResponse = WorkOfArtResponse(
             id = blueDawn.id.value.toString(),
             user = blueDawn.user.value.toString(),
-            title = "test-title",
-            imageUrl = "test-image-url",
+            title = "Blue Dawn",
+            imageUrl = "https://example.com/blue-dawn.jpg",
             medium = "pan pastels",
             createdAt = blueDawn.createdAt.toString(),
         )
@@ -106,6 +125,77 @@ class WorkOfArtServiceTest {
 
         // When
         val result = workOfArtService.getWorkOfArtById(blueDawn.id.value.toString())
+
+        // Then
+        assertEquals(expectedResponse, result)
+    }
+
+    @Test
+    fun getAllWorksOfArtNoMediumsSpecified() {
+        // Given
+        val expectedResponse = listOf(
+            WorkOfArtShortResponse(
+                id = redMidday.id.value.toString(),
+                user = redMidday.user.value.toString(),
+                title = "Red Midday",
+                imageUrl = "https://example.com/red-midday.jpg",
+                medium = "watercolors",
+                createdAt = redMidday.createdAt.toString(),
+            ),
+            WorkOfArtShortResponse(
+                id = blueDawn.id.value.toString(),
+                user = blueDawn.user.value.toString(),
+                title = "Blue Dawn",
+                imageUrl = "https://example.com/blue-dawn.jpg",
+                medium = "pan pastels",
+                createdAt = blueDawn.createdAt.toString(),
+            ),
+            WorkOfArtShortResponse(
+                id = yellowSunset.id.value.toString(),
+                user = yellowSunset.user.value.toString(),
+                title = "Yellow Sunset",
+                imageUrl = "https://example.com/yellow-sunset.jpg",
+                medium = "watercolors",
+                createdAt = yellowSunset.createdAt.toString(),
+            ),
+
+        )
+
+        every { workOfArtRepo.findAll() } returns listOf(redMidday, yellowSunset, blueDawn)
+
+        // When
+        val result = workOfArtService.getAllWorksOfArt()
+
+        // Then
+        assertEquals(expectedResponse, result)
+    }
+
+    @Test
+    fun getAllWorksOfArtWithMediumsSpecified() {
+        // Given
+        val expectedResponse = listOf(
+            WorkOfArtShortResponse(
+                id = redMidday.id.value.toString(),
+                user = redMidday.user.value.toString(),
+                title = "Red Midday",
+                imageUrl = "https://example.com/red-midday.jpg",
+                medium = "watercolors",
+                createdAt = redMidday.createdAt.toString(),
+            ),
+            WorkOfArtShortResponse(
+                id = yellowSunset.id.value.toString(),
+                user = yellowSunset.user.value.toString(),
+                title = "Yellow Sunset",
+                imageUrl = "https://example.com/yellow-sunset.jpg",
+                medium = "watercolors",
+                createdAt = yellowSunset.createdAt.toString(),
+            ),
+        )
+
+        every { workOfArtRepo.findAllByMediumIn(listOf(Medium.WATERCOLORS)) } returns listOf(redMidday, yellowSunset)
+
+        // When
+        val result = workOfArtService.getAllWorksOfArt(listOf(Medium.WATERCOLORS))
 
         // Then
         assertEquals(expectedResponse, result)

--- a/frontend/src/components/WorkOfArtComponent.tsx
+++ b/frontend/src/components/WorkOfArtComponent.tsx
@@ -37,7 +37,7 @@ function useUser(userId: string | undefined) {
             setLoading(true);
             try {
                 const response = await axios.get<User>('/api/user/', {
-                    params: { id: userId }
+                    params: {id: userId}
                 });
                 setUser(response.data);
                 setError(null);
@@ -51,14 +51,19 @@ function useUser(userId: string | undefined) {
         void fetchUser();
     }, [userId]);
 
-    return { user, loading, error };
+    return {user, loading, error};
 }
 
-export default function WorkOfArtComponent({workOfArtId, allFields = true}: WorkOfArtComponentProps & { allFields?: boolean }) {
+export default function WorkOfArtComponent({
+                                               workOfArtId,
+                                               allFields = true
+                                           }: WorkOfArtComponentProps & {
+    allFields?: boolean
+}) {
     const [workOfArt, setWorkOfArt] = useState<WorkOfArt | null>(null);
     const [workOfArtLoading, setWorkOfArtLoading] = useState(true);
     const [workOfArtError, setWorkOfArtError] = useState<string | null>(null);
-    const { user, loading: userLoading, error: userError } = useUser(workOfArt?.user);
+    const {user, loading: userLoading, error: userError} = useUser(workOfArt?.user);
 
     useEffect(() => {
         async function fetchWorkOfArt(workOfArtId: string | undefined) {
@@ -82,10 +87,12 @@ export default function WorkOfArtComponent({workOfArtId, allFields = true}: Work
         void fetchWorkOfArt(workOfArtId);
     }, [workOfArtId]);
 
-    if (workOfArtLoading || userLoading) return <div className="mt-24 text-center">Loading...</div>;
+    if (workOfArtLoading || userLoading) return <div
+        className="mt-24 text-center">Loading...</div>;
     if (workOfArtError || userError) return <div
         className="mt-24 text-center text-red-500">Error: {workOfArtError}</div>;
-    if (!workOfArt || !user) return <div className="mt-24 text-center">No work of art data
+    if (!workOfArt || !user) return <div className="mt-24 text-center">No work of art
+        data
         available</div>;
 
     return (
@@ -122,42 +129,43 @@ export default function WorkOfArtComponent({workOfArtId, allFields = true}: Work
                         <p className="text-gray-600">{formatDate(workOfArt.createdAt)}</p>
                     </div>
                 </div>
-            { allFields && (
-                <>
-                {/* Description Section */}
-                <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
-                    <h3 className="text-xl font-semibold text-gray-800 mb-4">Description</h3>
-                    <p className="text-gray-600">
-                        {workOfArt.description || 'No description yet 🌳'}
-                    </p>
-                </div>
-
-                {/* Materials Section */}
-                {workOfArt.materials && workOfArt.materials.length > 0 && (
-                    <div
-                        className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
-                        <h3 className="text-xl font-semibold text-gray-800 mb-4">Materials</h3>
-                        {workOfArt.materials.map((material, index) => (
-                            <p key={index} className="text-gray-600">
-                                {/* TODO: Different material description depending on what's available */}
-                                {material.type} {material.identifier} - {material.name} by {material.brand} ({material.line})
+                {allFields && (
+                    <>
+                        {/* Description Section */}
+                        <div
+                            className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                            <h3 className="text-xl font-semibold text-gray-800 mb-4">Description</h3>
+                            <p className="text-gray-600">
+                                {workOfArt.description || 'No description yet 🌳'}
                             </p>
-                        ))}
-                    </div>
-                )}
+                        </div>
 
-                {/* Challenge Section */}
-                {workOfArt.challengeId && (
-                    <div
-                        className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
-                        <h3 className="text-xl font-semibold text-gray-800 mb-4">Challenge</h3>
-                        <p className="text-gray-600">
-                            See challenge: {workOfArt.challengeId}
-                        </p>
-                    </div>
+                        {/* Materials Section */}
+                        {workOfArt.materials && workOfArt.materials.length > 0 && (
+                            <div
+                                className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                                <h3 className="text-xl font-semibold text-gray-800 mb-4">Materials</h3>
+                                {workOfArt.materials.map((material, index) => (
+                                    <p key={index} className="text-gray-600">
+                                        {/* TODO: Different material description depending on what's available */}
+                                        {material.type} {material.identifier} - {material.name} by {material.brand} ({material.line})
+                                    </p>
+                                ))}
+                            </div>
+                        )}
+
+                        {/* Challenge Section */}
+                        {workOfArt.challengeId && (
+                            <div
+                                className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                                <h3 className="text-xl font-semibold text-gray-800 mb-4">Challenge</h3>
+                                <p className="text-gray-600">
+                                    See challenge: {workOfArt.challengeId}
+                                </p>
+                            </div>
+                        )}
+                    </>
                 )}
-                </>
-            )}
             </div>
         </div>
     );

--- a/frontend/src/components/WorkOfArtComponent.tsx
+++ b/frontend/src/components/WorkOfArtComponent.tsx
@@ -115,7 +115,7 @@ export default function WorkOfArtComponent({workOfArtId}: WorkOfArtComponentProp
                     className="flex justify-between bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
                     <div>
                         <h3 className="text-2xl font-semibold text-gray-800">
-                            {workOfArt.title}
+                            <a href={`/woa/${workOfArt.id}`}>{workOfArt.title}</a>
                         </h3>
                     </div>
                     <div>

--- a/frontend/src/components/WorkOfArtComponent.tsx
+++ b/frontend/src/components/WorkOfArtComponent.tsx
@@ -1,9 +1,7 @@
-import {useEffect, useState} from "react";
-import {WorkOfArt} from "../types.tsx";
-import axios from "axios";
+import { WorkOfArt } from "../types.tsx";
 
 type WorkOfArtComponentProps = {
-    workOfArtId?: string;
+    workOfArt: WorkOfArt;
     allFields?: boolean;
 };
 
@@ -23,48 +21,12 @@ function formatDate(dateString: string): string {
     return `${day}/${month}/${year}`;
 }
 
-export default function WorkOfArtComponent({
-                                               workOfArtId,
-                                               allFields = true
-                                           }: WorkOfArtComponentProps) {
-    const [workOfArt, setWorkOfArt] = useState<WorkOfArt | null>(null);
-    const [workOfArtLoading, setWorkOfArtLoading] = useState(true);
-    const [workOfArtError, setWorkOfArtError] = useState<string | null>(null);
-
-    useEffect(() => {
-        async function fetchWorkOfArt(workOfArtId: string | undefined) {
-            if (!workOfArtId) {
-                setWorkOfArtError('Work of art ID is required');
-                setWorkOfArtLoading(false);
-                return;
-            }
-            setWorkOfArtLoading(true);  // Reset loading when workOfArtId changes
-            try {
-                const response = await axios.get<WorkOfArt>('/api/woa/' + workOfArtId);
-                setWorkOfArt(response.data);
-                setWorkOfArtError(null);
-            } catch (error) {
-                setWorkOfArtError(error instanceof Error ? error.message : String(error));
-            } finally {
-                setWorkOfArtLoading(false);
-            }
-        }
-
-        void fetchWorkOfArt(workOfArtId);
-    }, [workOfArtId]);
-
-    if (workOfArtLoading) return <div className="mt-24 text-center">Loading...</div>;
-    if (workOfArtError) return <div
-        className="mt-24 text-center text-red-500">Error: {workOfArtError}</div>;
-    if (!workOfArt) return <div className="mt-24 text-center">No work of art data
-        available</div>;
-
+export default function WorkOfArtComponent({ workOfArt, allFields = true }: WorkOfArtComponentProps) {
     return (
         <div className="container mx-auto px-4 mt-24">
             <div className="max-w-2xl mx-auto space-y-6">
                 {/* User and Medium Section */}
-                <div
-                    className="flex justify-between bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                <div className="flex justify-between bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
                     <div>
                         <h2 className="text-2xl font-semibold text-gray-800">
                             <a href={`/user/${workOfArt.userName}`}>{workOfArt.userName}</a>
@@ -77,13 +39,11 @@ export default function WorkOfArtComponent({
 
                 {/* Image Section */}
                 <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
-                    <img src={transformImageUrl(workOfArt.imageUrl)}
-                         alt={workOfArt.title} className="w-full rounded-lg"/>
+                    <img src={transformImageUrl(workOfArt.imageUrl)} alt={workOfArt.title} className="w-full rounded-lg" />
                 </div>
 
                 {/* Title Section */}
-                <div
-                    className="flex justify-between bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                <div className="flex justify-between bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
                     <div>
                         <h3 className="text-2xl font-semibold text-gray-800">
                             <a href={`/woa/${workOfArt.id}`}>{workOfArt.title}</a>
@@ -96,8 +56,7 @@ export default function WorkOfArtComponent({
                 {allFields && (
                     <>
                         {/* Description Section */}
-                        <div
-                            className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                        <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
                             <h3 className="text-xl font-semibold text-gray-800 mb-4">Description</h3>
                             <p className="text-gray-600">
                                 {workOfArt.description || 'No description yet 🌳'}
@@ -106,8 +65,7 @@ export default function WorkOfArtComponent({
 
                         {/* Materials Section */}
                         {workOfArt.materials && workOfArt.materials.length > 0 && (
-                            <div
-                                className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                            <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
                                 <h3 className="text-xl font-semibold text-gray-800 mb-4">Materials</h3>
                                 {workOfArt.materials.map((material, index) => (
                                     <p key={index} className="text-gray-600">
@@ -119,8 +77,7 @@ export default function WorkOfArtComponent({
 
                         {/* Challenge Section */}
                         {workOfArt.challengeId && (
-                            <div
-                                className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+                            <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
                                 <h3 className="text-xl font-semibold text-gray-800 mb-4">Challenge</h3>
                                 <p className="text-gray-600">
                                     See challenge: {workOfArt.challengeId}

--- a/frontend/src/components/WorkOfArtComponent.tsx
+++ b/frontend/src/components/WorkOfArtComponent.tsx
@@ -54,7 +54,7 @@ function useUser(userId: string | undefined) {
     return { user, loading, error };
 }
 
-export default function WorkOfArtComponent({workOfArtId}: WorkOfArtComponentProps) {
+export default function WorkOfArtComponent({workOfArtId, allFields = true}: WorkOfArtComponentProps & { allFields?: boolean }) {
     const [workOfArt, setWorkOfArt] = useState<WorkOfArt | null>(null);
     const [workOfArtLoading, setWorkOfArtLoading] = useState(true);
     const [workOfArtError, setWorkOfArtError] = useState<string | null>(null);
@@ -122,7 +122,8 @@ export default function WorkOfArtComponent({workOfArtId}: WorkOfArtComponentProp
                         <p className="text-gray-600">{formatDate(workOfArt.createdAt)}</p>
                     </div>
                 </div>
-
+            { allFields && (
+                <>
                 {/* Description Section */}
                 <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
                     <h3 className="text-xl font-semibold text-gray-800 mb-4">Description</h3>
@@ -155,6 +156,8 @@ export default function WorkOfArtComponent({workOfArtId}: WorkOfArtComponentProp
                         </p>
                     </div>
                 )}
+                </>
+            )}
             </div>
         </div>
     );

--- a/frontend/src/components/WorkOfArtComponent.tsx
+++ b/frontend/src/components/WorkOfArtComponent.tsx
@@ -1,9 +1,10 @@
 import {useEffect, useState} from "react";
-import {User, WorkOfArt} from "../types.tsx";
+import {WorkOfArt} from "../types.tsx";
 import axios from "axios";
 
 type WorkOfArtComponentProps = {
     workOfArtId?: string;
+    allFields?: boolean;
 };
 
 function transformImageUrl(url: string): string {
@@ -22,48 +23,13 @@ function formatDate(dateString: string): string {
     return `${day}/${month}/${year}`;
 }
 
-function useUser(userId: string | undefined) {
-    const [user, setUser] = useState<User | null>(null);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-
-    useEffect(() => {
-        if (!userId) {
-            setLoading(false);
-            return;
-        }
-
-        async function fetchUser() {
-            setLoading(true);
-            try {
-                const response = await axios.get<User>('/api/user/', {
-                    params: {id: userId}
-                });
-                setUser(response.data);
-                setError(null);
-            } catch (error) {
-                setError(error instanceof Error ? error.message : String(error));
-            } finally {
-                setLoading(false);
-            }
-        }
-
-        void fetchUser();
-    }, [userId]);
-
-    return {user, loading, error};
-}
-
 export default function WorkOfArtComponent({
                                                workOfArtId,
                                                allFields = true
-                                           }: WorkOfArtComponentProps & {
-    allFields?: boolean
-}) {
+                                           }: WorkOfArtComponentProps) {
     const [workOfArt, setWorkOfArt] = useState<WorkOfArt | null>(null);
     const [workOfArtLoading, setWorkOfArtLoading] = useState(true);
     const [workOfArtError, setWorkOfArtError] = useState<string | null>(null);
-    const {user, loading: userLoading, error: userError} = useUser(workOfArt?.user);
 
     useEffect(() => {
         async function fetchWorkOfArt(workOfArtId: string | undefined) {
@@ -87,12 +53,10 @@ export default function WorkOfArtComponent({
         void fetchWorkOfArt(workOfArtId);
     }, [workOfArtId]);
 
-    if (workOfArtLoading || userLoading) return <div
-        className="mt-24 text-center">Loading...</div>;
-    if (workOfArtError || userError) return <div
+    if (workOfArtLoading) return <div className="mt-24 text-center">Loading...</div>;
+    if (workOfArtError) return <div
         className="mt-24 text-center text-red-500">Error: {workOfArtError}</div>;
-    if (!workOfArt || !user) return <div className="mt-24 text-center">No work of art
-        data
+    if (!workOfArt) return <div className="mt-24 text-center">No work of art data
         available</div>;
 
     return (
@@ -103,7 +67,7 @@ export default function WorkOfArtComponent({
                     className="flex justify-between bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
                     <div>
                         <h2 className="text-2xl font-semibold text-gray-800">
-                            <a href={`/user/${user.name}`}>{user.name}</a>
+                            <a href={`/user/${workOfArt.userName}`}>{workOfArt.userName}</a>
                         </h2>
                     </div>
                     <div>
@@ -147,7 +111,6 @@ export default function WorkOfArtComponent({
                                 <h3 className="text-xl font-semibold text-gray-800 mb-4">Materials</h3>
                                 {workOfArt.materials.map((material, index) => (
                                     <p key={index} className="text-gray-600">
-                                        {/* TODO: Different material description depending on what's available */}
                                         {material.type} {material.identifier} - {material.name} by {material.brand} ({material.line})
                                     </p>
                                 ))}

--- a/frontend/src/pages/Feed.tsx
+++ b/frontend/src/pages/Feed.tsx
@@ -1,31 +1,41 @@
-import { useEffect, useState } from "react";
+import {useEffect, useState} from "react";
 import axios from "axios";
+import WorkOfArtComponent from "../components/WorkOfArtComponent";
+import {WorkOfArt} from "../types.tsx";
 
 export default function Feed() {
-    const [status, setStatus] = useState<string>('');
+    const [worksOfArt, setWorksOfArt] = useState<WorkOfArt[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
-        async function fetchStatus() {
+        async function fetchWorksOfArt() {
             try {
-                const response = await axios.get<string>('/api/status');
-                setStatus(response.data);
+                const response = await axios.get<WorkOfArt[]>('/api/woa');
+                setWorksOfArt(response.data);
+                setError(null);
             } catch (error) {
                 setError(error instanceof Error ? error.message : 'An error occurred');
             } finally {
                 setLoading(false);
             }
         }
-        void fetchStatus();
+
+        void fetchWorksOfArt();
     }, []);
 
-    if (loading) return <div>Loading...</div>;
-    if (error) return <div>Error: {error}</div>;
+    if (loading) return <div className="mt-24 text-center">Loading...</div>;
+    if (error) return <div
+        className="mt-24 text-center text-red-500">Error: {error}</div>;
 
     return (
-        <div>
-            <p>The status of the backend is: {status}</p>
+        <div className="container mx-auto px-4 mt-24 pb-24">
+            <div className="max-w-2xl mx-auto space-y-6">
+                {worksOfArt.map(workOfArt => (
+                    <WorkOfArtComponent key={workOfArt.id} workOfArt={workOfArt}
+                                        allFields={false}/>
+                ))}
+            </div>
         </div>
     );
 }

--- a/frontend/src/pages/WorkOfArtPage.tsx
+++ b/frontend/src/pages/WorkOfArtPage.tsx
@@ -1,13 +1,46 @@
+import {useEffect, useState} from "react";
 import {useParams} from "react-router-dom";
-import WorkOfArt from "../components/WorkOfArtComponent.tsx";
+import axios from "axios";
+import WorkOfArtComponent from "../components/WorkOfArtComponent.tsx";
+import {WorkOfArt} from "../types.tsx";
 
 export default function WorkOfArtPage() {
-
     const {workOfArtId} = useParams<{ workOfArtId?: string }>();
+    const [workOfArt, setWorkOfArt] = useState<WorkOfArt | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        async function fetchWorkOfArt(workOfArtId: string | undefined) {
+            if (!workOfArtId) {
+                setError('Work of art ID is required');
+                setLoading(false);
+                return;
+            }
+            setLoading(true);
+            try {
+                const response = await axios.get<WorkOfArt>('/api/woa/' + workOfArtId);
+                setWorkOfArt(response.data);
+                setError(null);
+            } catch (error) {
+                setError(error instanceof Error ? error.message : String(error));
+            } finally {
+                setLoading(false);
+            }
+        }
+
+        void fetchWorkOfArt(workOfArtId);
+    }, [workOfArtId]);
+
+    if (loading) return <div className="mt-24 text-center">Loading...</div>;
+    if (error) return <div
+        className="mt-24 text-center text-red-500">Error: {error}</div>;
+    if (!workOfArt) return <div className="mt-24 text-center">No work of art data
+        available</div>;
 
     return (
         <div className="pb-24">
-            <WorkOfArt workOfArtId={workOfArtId}/>
+            <WorkOfArtComponent workOfArt={workOfArt}/>
         </div>
     );
 }

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -34,6 +34,7 @@ export type Material = {
 export type WorkOfArt = {
     id: string;
     user: string;
+    userName: string,
     challengeId: string | null;
     title: string;
     description: string | null;


### PR DESCRIPTION
Closes: #2 

With this PR, the Feed page displays all posts.

- GET endpoint for /woa/ is added to the backend to get all works of art, in reverse time order
- to avoid too many API call, the userName field is added to the WorkOfArt data model and response
- the Feed page shows all works of art
- the WorkOfArtPage is refactored to take the responsibility of fetching the payload of the single work of art, so that the component receives the payload from outside; this way, the Feed page can re-use the WorkOfArtComponent

<img width="837" alt="image" src="https://github.com/user-attachments/assets/5f051761-ff1f-4ec0-a9e7-4f884662e70e" />
