### PR TITLE
feat: Create a new user upon login

### DIFF
--- a/backend/src/main/kotlin/de/neuefische/backend/security/AuthController.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/security/AuthController.kt
@@ -1,5 +1,6 @@
 package de.neuefische.backend.security
 
+import de.neuefische.backend.user.UserService
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.web.bind.annotation.GetMapping
@@ -8,9 +9,23 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/auth")
-class AuthController {
+class AuthController(
+    private val userService: UserService,
+) {
     @GetMapping("/me")
     fun getMe(
         @AuthenticationPrincipal user: OAuth2User?,
-    ): String = user?.attributes?.get("login")?.toString() ?: ""
+    ): String {
+        if (user == null) {
+            return ""
+        }
+
+        val oauthUsername: String = user.attributes["login"]?.toString() ?: ""
+
+        if (oauthUsername.isEmpty()) {
+            return ""
+        }
+
+        return userService.findOrCreateUser(oauthUsername).name
+    }
 }

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserService.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserService.kt
@@ -28,4 +28,17 @@ class UserService(
                 mediums = user.mediums?.map { it.lowercase } ?: emptyList(),
             )
         }
+
+    private fun createUser(oauthUsername: String): User {
+        val user =
+            User(
+                name = oauthUsername,
+                bio = "",
+                imageUrl = "",
+                mediums = emptyList(),
+            )
+        return userRepo.save(user)
+    }
+
+    fun findOrCreateUser(oauthUsername: String): User = userRepo.findByName(oauthUsername) ?: createUser(oauthUsername)
 }

--- a/backend/src/test/kotlin/de/neuefische/backend/security/AuthControllerTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/security/AuthControllerTest.kt
@@ -1,5 +1,12 @@
 package de.neuefische.backend.security
 
+import com.ninjasquad.springmockk.MockkBean
+import de.neuefische.backend.common.Medium
+import de.neuefische.backend.user.User
+import de.neuefische.backend.user.UserRepo
+import io.mockk.every
+import io.mockk.verify
+import org.bson.BsonObjectId
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -17,9 +24,27 @@ class AuthControllerTest {
     @Autowired
     private lateinit var mockMvc: MockMvc
 
+    @MockkBean
+    private lateinit var userRepo: UserRepo
+
     @Test
     @WithMockUser
-    fun `should return user name when authenticated`() {
+    fun `should return user name if logged in user exists`() {
+        val user =
+            User(
+                id = BsonObjectId(),
+                name = "existing-user",
+                bio = "test-bio",
+                imageUrl = "test-image-url",
+                mediums =
+                    listOf(
+                        Medium.WATERCOLORS,
+                        Medium.INK,
+                    ),
+            )
+
+        every { userRepo.findByName("existing-user") } returns user
+
         mockMvc
             .perform(
                 MockMvcRequestBuilders
@@ -30,12 +55,13 @@ class AuthControllerTest {
                             .userInfoToken { token: OidcUserInfo.Builder ->
                                 token.claim(
                                     "login",
-                                    "user",
+                                    "existing-user",
                                 )
                             },
                     ),
             ).andExpect(MockMvcResultMatchers.status().isOk())
-            .andExpect(MockMvcResultMatchers.content().string("user"))
+            .andExpect(MockMvcResultMatchers.content().string("existing-user"))
+        verify(exactly = 0) { userRepo.save(any()) }
     }
 
     @Test
@@ -65,5 +91,30 @@ class AuthControllerTest {
                     ),
             ).andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.content().string(""))
+    }
+
+    @Test
+    @WithMockUser
+    fun `should create user if logged in user not found`() {
+        every { userRepo.findByName("new-user") } returns null
+        every { userRepo.save(any()) } answers { firstArg() }
+
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .get("/api/auth/me")
+                    .with(
+                        SecurityMockMvcRequestPostProcessors
+                            .oidcLogin()
+                            .userInfoToken { token: OidcUserInfo.Builder ->
+                                token.claim(
+                                    "login",
+                                    "new-user",
+                                )
+                            },
+                    ),
+            ).andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.content().string("new-user"))
+        verify { userRepo.save(any()) }
     }
 }

--- a/backend/src/test/kotlin/de/neuefische/backend/security/AuthControllerTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/security/AuthControllerTest.kt
@@ -19,7 +19,7 @@ class AuthControllerTest {
 
     @Test
     @WithMockUser
-    fun me_whenAuthenticated_returnsUserName() {
+    fun `should return user name when authenticated`() {
         mockMvc
             .perform(
                 MockMvcRequestBuilders
@@ -39,7 +39,7 @@ class AuthControllerTest {
     }
 
     @Test
-    fun me_WhenNotAuthenticated_returnsEmptyUser() {
+    fun `should return empty string when not authenticated`() {
         mockMvc
             .perform(MockMvcRequestBuilders.get("/api/auth/me"))
             .andExpect(MockMvcResultMatchers.status().isOk())
@@ -48,7 +48,7 @@ class AuthControllerTest {
 
     @Test
     @WithMockUser
-    fun me_whenLoginNotFound_returnsEmptyUser() {
+    fun `should return empty string when login not found`() {
         mockMvc
             .perform(
                 MockMvcRequestBuilders

--- a/backend/src/test/kotlin/de/neuefische/backend/user/UserServiceTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/user/UserServiceTest.kt
@@ -3,6 +3,7 @@ package de.neuefische.backend.user
 import de.neuefische.backend.common.Medium
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.bson.BsonObjectId
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -13,7 +14,7 @@ class UserServiceTest {
     private val userService = UserService(userRepo)
 
     @Test
-    fun getUserByName() {
+    fun `should return user profile when user exists by name`() {
         // Given
         val user =
             User(
@@ -44,11 +45,12 @@ class UserServiceTest {
 
         // Then
         assertEquals(expectedResponse, result)
+        verify { userRepo.findByName("test-user") }
     }
 
     // add test for nonexistent name
     @Test
-    fun getUserByNameNonExistent() {
+    fun `should return null when user does not exist by name`() {
         // Given
         every { userRepo.findByName("test-user") } returns null
 
@@ -57,10 +59,11 @@ class UserServiceTest {
 
         // Then
         assertEquals(null, result)
+        verify { userRepo.findByName("test-user") }
     }
 
     @Test
-    fun getUserById() {
+    fun `should return user profile when user exists by id`() {
         // Given
         val user =
             User(
@@ -91,11 +94,11 @@ class UserServiceTest {
 
         // Then
         assertEquals(expectedResponse, result)
+        verify { userRepo.findByIdOrNull(user.id.value.toString()) }
     }
 
-    // add test for nonexistent id
     @Test
-    fun getUserByIdNonExistent() {
+    fun `should return null when user does not exist by id`() {
         // Given
         every { userRepo.findByIdOrNull("test-id") } returns null
 
@@ -104,5 +107,6 @@ class UserServiceTest {
 
         // Then
         assertEquals(null, result)
+        verify { userRepo.findByIdOrNull("test-id") }
     }
 }

--- a/backend/src/test/kotlin/de/neuefische/backend/user/UserServiceTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/user/UserServiceTest.kt
@@ -109,4 +109,44 @@ class UserServiceTest {
         assertEquals(null, result)
         verify { userRepo.findByIdOrNull("test-id") }
     }
+
+    @Test
+    fun `should create user if it does not exist`() {
+        // Given
+        every { userRepo.findByName("test-user") } returns null
+        every { userRepo.save(any()) } answers { firstArg() }
+
+        // When
+        val result: User = userService.findOrCreateUser("test-user")
+
+        // Then
+        assertEquals("test-user", result.name)
+        verify { userRepo.save(any()) }
+    }
+
+    @Test
+    fun `should return user if it exists`() {
+        // Given
+        val user =
+            User(
+                id = BsonObjectId(),
+                name = "test-user",
+                bio = "test-bio",
+                imageUrl = "test-image-url",
+                mediums =
+                    listOf(
+                        Medium.WATERCOLORS,
+                        Medium.INK,
+                    ),
+            )
+
+        every { userRepo.findByName("test-user") } returns user
+
+        // When
+        val result: User = userService.findOrCreateUser("test-user")
+
+        // Then
+        assertEquals("test-user", result.name)
+        verify(exactly = 0) { userRepo.save(any()) }
+    }
 }


### PR DESCRIPTION
Closes: #28
Closes: #14 

With this PR, a new user is added to the db with the Github username if the user logs in but their name is not found in the database.

Additionally, in the modified test files, existing tests are renamed in a way more idiomatic to kotlin.


Screenshot from the db with my github handle:
<img width="699" alt="image" src="https://github.com/user-attachments/assets/fafa6e6f-a8aa-4c02-8dcd-b64345b3b818" />
