### PR TITLE
feat: Edit the user profile

### DIFF
--- a/backend/src/main/kotlin/de/neuefische/backend/common/Medium.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/common/Medium.kt
@@ -18,4 +18,4 @@ enum class Medium(
     WATERCOLORS("watercolors"),
 }
 
-fun String.toMedium(): Medium? = Medium.entries.find { it.name.equals(this, ignoreCase = true) }
+fun String.toMedium(): Medium? = Medium.entries.find { it.lowercase.equals(this, ignoreCase = true) }

--- a/backend/src/main/kotlin/de/neuefische/backend/exceptions/CustomExceptions.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/exceptions/CustomExceptions.kt
@@ -3,3 +3,7 @@ package de.neuefische.backend.exceptions
 class NotFoundException(
     message: String,
 ) : Exception(message)
+
+class UnauthorizedException(
+    message: String,
+) : Exception(message)

--- a/backend/src/main/kotlin/de/neuefische/backend/exceptions/GlobalExceptionHandler.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/exceptions/GlobalExceptionHandler.kt
@@ -38,12 +38,4 @@ class GlobalExceptionHandler {
             status = HttpStatus.FORBIDDEN,
             message = exception.message ?: "Access denied",
         )
-
-    @ExceptionHandler
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    fun handleUnauthorizedException(exception: UnauthorizedException): ErrorMessage =
-        ErrorMessage(
-            status = HttpStatus.UNAUTHORIZED,
-            message = exception.message ?: "Unauthorized",
-        )
 }

--- a/backend/src/main/kotlin/de/neuefische/backend/exceptions/GlobalExceptionHandler.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/exceptions/GlobalExceptionHandler.kt
@@ -30,4 +30,20 @@ class GlobalExceptionHandler {
             status = HttpStatus.NOT_FOUND,
             message = exception.message ?: "Not found",
         )
+
+    @ExceptionHandler()
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    fun handleAccessDeniedException(exception: AccessDeniedException): ErrorMessage =
+        ErrorMessage(
+            status = HttpStatus.FORBIDDEN,
+            message = exception.message ?: "Access denied",
+        )
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    fun handleUnauthorizedException(exception: UnauthorizedException): ErrorMessage =
+        ErrorMessage(
+            status = HttpStatus.UNAUTHORIZED,
+            message = exception.message ?: "Unauthorized",
+        )
 }

--- a/backend/src/main/kotlin/de/neuefische/backend/exceptions/GlobalExceptionHandler.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/exceptions/GlobalExceptionHandler.kt
@@ -22,4 +22,12 @@ class GlobalExceptionHandler {
             status = HttpStatus.BAD_REQUEST,
             message = exception.message ?: "Bad request",
         )
+
+    @ExceptionHandler()
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    fun handleNotFoundException(exception: NoSuchElementException): ErrorMessage =
+        ErrorMessage(
+            status = HttpStatus.NOT_FOUND,
+            message = exception.message ?: "Not found",
+        )
 }

--- a/backend/src/main/kotlin/de/neuefische/backend/exceptions/NotFoundException.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/exceptions/NotFoundException.kt
@@ -1,0 +1,5 @@
+package de.neuefische.backend.exceptions
+
+class NotFoundException(
+    message: String,
+) : Exception(message)

--- a/backend/src/main/kotlin/de/neuefische/backend/exceptions/NotFoundException.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/exceptions/NotFoundException.kt
@@ -3,7 +3,3 @@ package de.neuefische.backend.exceptions
 class NotFoundException(
     message: String,
 ) : Exception(message)
-
-class UnauthorizedException(
-    message: String,
-) : Exception(message)

--- a/backend/src/main/kotlin/de/neuefische/backend/security/AuthController.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/security/AuthController.kt
@@ -1,8 +1,6 @@
 package de.neuefische.backend.security
 
 import de.neuefische.backend.user.UserService
-import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -11,21 +9,11 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/auth")
 class AuthController(
     private val userService: UserService,
+    private val securityService: SecurityService,
 ) {
     @GetMapping("/me")
-    fun getMe(
-        @AuthenticationPrincipal user: OAuth2User?,
-    ): String {
-        if (user == null) {
-            return ""
-        }
-
-        val oauthUsername: String = user.attributes["login"]?.toString() ?: ""
-
-        if (oauthUsername.isEmpty()) {
-            return ""
-        }
-
-        return userService.findOrCreateUser(oauthUsername).name
+    fun getMe(): String {
+        val username = securityService.getCurrentUsername() ?: return ""
+        return userService.findOrCreateUser(username).name
     }
 }

--- a/backend/src/main/kotlin/de/neuefische/backend/security/SecurityService.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/security/SecurityService.kt
@@ -1,0 +1,16 @@
+package de.neuefische.backend.security
+
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Service
+
+@Service
+class SecurityService {
+    fun getCurrentUsername(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication
+        if (authentication?.principal !is OAuth2User) return null
+
+        val oAuth2User = authentication.principal as OAuth2User
+        return oAuth2User.attributes["login"]?.toString()
+    }
+}

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserController.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserController.kt
@@ -1,7 +1,11 @@
 package de.neuefische.backend.user
 
+import de.neuefische.backend.exceptions.NotFoundException
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -29,6 +33,27 @@ class UserController(
             ResponseEntity.ok(userProfile)
         } else {
             ResponseEntity.notFound().build()
+        }
+    }
+
+    @PutMapping("/{id}")
+    fun updateUser(
+        @PathVariable id: String,
+        @RequestBody req: UserProfileUpdateRequest,
+    ): ResponseEntity<UserProfileResponse> {
+        try {
+            val updatedUser = userService.updateUser(id, req)
+            return ResponseEntity.ok(
+                UserProfileResponse(
+                    id = updatedUser.id.value.toString(),
+                    name = updatedUser.name,
+                    bio = updatedUser.bio,
+                    imageUrl = updatedUser.imageUrl,
+                    mediums = updatedUser.mediums?.map { it.lowercase } ?: emptyList(),
+                ),
+            )
+        } catch (e: NotFoundException) {
+            return ResponseEntity.notFound().build()
         }
     }
 }

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserController.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserController.kt
@@ -45,11 +45,7 @@ class UserController(
         @PathVariable id: String,
         @RequestBody req: UserProfileUpdateRequest,
     ): ResponseEntity<UserProfileResponse> {
-        val currentUser =
-            securityService.getCurrentUsername() ?: return ResponseEntity
-                .status(
-                    HttpStatus.UNAUTHORIZED,
-                ).build()
+        val currentUser = securityService.getCurrentUsername() ?: ""
         try {
             val updatedUser = userService.updateUser(id, req, currentUser)
             return ResponseEntity.ok(

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserProfileUpdateRequest.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserProfileUpdateRequest.kt
@@ -1,0 +1,7 @@
+package de.neuefische.backend.user
+
+data class UserProfileUpdateRequest(
+    val bio: String?,
+    val imageUrl: String?,
+    val mediums: List<String>,
+)

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserService.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserService.kt
@@ -3,6 +3,7 @@ package de.neuefische.backend.user
 import de.neuefische.backend.common.toMedium
 import de.neuefische.backend.exceptions.NotFoundException
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.stereotype.Service
 
 @Service
@@ -47,10 +48,15 @@ class UserService(
     fun updateUser(
         userId: String,
         req: UserProfileUpdateRequest,
+        currentUser: String,
     ): User {
         val user =
             userRepo.findByIdOrNull(userId)
                 ?: throw NotFoundException("User $userId not found")
+
+        if (currentUser != user.name) {
+            throw AccessDeniedException("You can only update your own profile")
+        }
 
         val updatedUser =
             user.copy(

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserService.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserService.kt
@@ -47,7 +47,9 @@ class UserService(
         userId: String,
         req: UserProfileUpdateRequest,
     ): User {
-        val user = userRepo.findByIdOrNull(userId) ?: throw IllegalArgumentException("User not found")
+        val user =
+            userRepo.findByIdOrNull(userId)
+                ?: throw IllegalArgumentException("User not found")
 
         val updatedUser =
             user.copy(

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserService.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserService.kt
@@ -1,6 +1,7 @@
 package de.neuefische.backend.user
 
 import de.neuefische.backend.common.toMedium
+import de.neuefische.backend.exceptions.NotFoundException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
@@ -49,7 +50,7 @@ class UserService(
     ): User {
         val user =
             userRepo.findByIdOrNull(userId)
-                ?: throw IllegalArgumentException("User not found")
+                ?: throw NotFoundException("User $userId not found")
 
         val updatedUser =
             user.copy(

--- a/backend/src/main/kotlin/de/neuefische/backend/user/UserService.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/user/UserService.kt
@@ -1,5 +1,6 @@
 package de.neuefische.backend.user
 
+import de.neuefische.backend.common.toMedium
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
@@ -41,4 +42,20 @@ class UserService(
     }
 
     fun findOrCreateUser(oauthUsername: String): User = userRepo.findByName(oauthUsername) ?: createUser(oauthUsername)
+
+    fun updateUser(
+        userId: String,
+        req: UserProfileUpdateRequest,
+    ): User {
+        val user = userRepo.findByIdOrNull(userId) ?: throw IllegalArgumentException("User not found")
+
+        val updatedUser =
+            user.copy(
+                bio = req.bio,
+                imageUrl = req.imageUrl,
+                mediums = req.mediums.mapNotNull { it.toMedium() },
+            )
+
+        return userRepo.save(updatedUser)
+    }
 }

--- a/backend/src/test/kotlin/de/neuefische/backend/common/MediumTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/common/MediumTest.kt
@@ -1,0 +1,29 @@
+package de.neuefische.backend.common
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class MediumTest {
+    @Test
+    fun `toMedium should return correct Medium enum for valid lowercase string`() {
+        assertEquals(Medium.ACRYLIC, "acrylic".toMedium())
+        assertEquals(Medium.OIL, "oil".toMedium())
+    }
+
+    @Test
+    fun `toMedium should return correct Medium enum for valid mixed case string`() {
+        assertEquals(Medium.WATERCOLORS, "Watercolors".toMedium())
+        assertEquals(Medium.INK, "InK".toMedium())
+    }
+
+    @Test
+    fun `toMedium should return null for invalid string`() {
+        assertNull("invalid".toMedium())
+    }
+
+    @Test
+    fun `toMedium should return null for empty string`() {
+        assertNull("".toMedium())
+    }
+}

--- a/backend/src/test/kotlin/de/neuefische/backend/security/SecurityServiceTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/security/SecurityServiceTest.kt
@@ -1,0 +1,72 @@
+package de.neuefische.backend.security
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.core.user.OAuth2User
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SecurityServiceTest {
+    private lateinit var securityService: SecurityService
+
+    @BeforeEach
+    fun setUp() {
+        securityService = SecurityService()
+        mockkStatic(SecurityContextHolder::class)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `getCurrentUsername should return username when authenticated`() {
+        val authentication = mockk<Authentication>()
+        val securityContext = mockk<SecurityContext>()
+        val oAuth2User = mockk<OAuth2User>()
+
+        every { SecurityContextHolder.getContext() } returns securityContext
+        every { securityContext.authentication } returns authentication
+        every { authentication.principal } returns oAuth2User
+        every { oAuth2User.attributes } returns mapOf("login" to "test-user")
+
+        val result = securityService.getCurrentUsername()
+
+        assertEquals("test-user", result)
+    }
+
+    @Test
+    fun `getCurrentUsername should return null when not authenticated`() {
+        val securityContext = mockk<SecurityContext>()
+
+        every { SecurityContextHolder.getContext() } returns securityContext
+        every { securityContext.authentication } returns null
+
+        val result = securityService.getCurrentUsername()
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `getCurrentUsername should return null when principal is not OAuth2User`() {
+        val authentication = mockk<Authentication>()
+        val securityContext = mockk<SecurityContext>()
+
+        every { SecurityContextHolder.getContext() } returns securityContext
+        every { securityContext.authentication } returns authentication
+        every { authentication.principal } returns "not-an-oauth2-user"
+
+        val result = securityService.getCurrentUsername()
+
+        assertNull(result)
+    }
+}

--- a/backend/src/test/kotlin/de/neuefische/backend/user/UserControllerTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/user/UserControllerTest.kt
@@ -1,14 +1,13 @@
 package de.neuefische.backend.user
 
-import com.ninjasquad.springmockk.MockkBean
 import de.neuefische.backend.common.Medium
-import io.mockk.every
 import org.bson.BsonObjectId
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -22,8 +21,18 @@ class UserControllerTest {
     @Autowired
     private lateinit var mockMvc: MockMvc
 
-    @MockkBean
+    @Autowired
     private lateinit var userRepo: UserRepo
+
+    @BeforeEach
+    fun setUp() {
+        userRepo.deleteAll()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        userRepo.deleteAll()
+    }
 
     @Test
     fun getUserByName() {
@@ -34,14 +43,9 @@ class UserControllerTest {
                 name = "test-user",
                 bio = "test-bio",
                 imageUrl = "test-image-url",
-                mediums =
-                    listOf(
-                        Medium.WATERCOLORS,
-                        Medium.INK,
-                    ),
+                mediums = listOf(Medium.WATERCOLORS, Medium.INK),
             )
-
-        every { userRepo.findByName("test-user") } returns user
+        userRepo.save(user)
 
         // When
         val result = mockMvc.perform(get("/api/user/").param("name", "test-user"))
@@ -66,8 +70,7 @@ class UserControllerTest {
                 id = BsonObjectId(),
                 name = "test-user",
             )
-
-        every { userRepo.findByName("test-user") } returns user
+        userRepo.save(user)
 
         // When
         val result = mockMvc.perform(get("/api/user/").param("name", "test-user"))
@@ -85,9 +88,6 @@ class UserControllerTest {
 
     @Test
     fun getUserByNameReturnsNotFound() {
-        // Given
-        every { userRepo.findByName("test-user") } returns null
-
         // When
         val result = mockMvc.perform(get("/api/user/").param("name", "test-user"))
 
@@ -105,14 +105,9 @@ class UserControllerTest {
                 name = "test-user",
                 bio = "test-bio",
                 imageUrl = "test-image-url",
-                mediums =
-                    listOf(
-                        Medium.WATERCOLORS,
-                        Medium.INK,
-                    ),
+                mediums = listOf(Medium.WATERCOLORS, Medium.INK),
             )
-
-        every { userRepo.findByIdOrNull(userId.value.toString()) } returns user
+        userRepo.save(user)
 
         // When
         val result = mockMvc.perform(get("/api/user/").param("id", userId.value.toString()))
@@ -138,8 +133,7 @@ class UserControllerTest {
                 id = userId,
                 name = "test-user",
             )
-
-        every { userRepo.findByIdOrNull(userId.value.toString()) } returns user
+        userRepo.save(user)
 
         // When
         val result = mockMvc.perform(get("/api/user/").param("id", userId.value.toString()))
@@ -159,7 +153,6 @@ class UserControllerTest {
     fun getUserByIdReturnsNotFound() {
         // Given
         val userId = BsonObjectId()
-        every { userRepo.findByIdOrNull(userId.value.toString()) } returns null
 
         // When
         val result = mockMvc.perform(get("/api/user/").param("id", userId.value.toString()))

--- a/backend/src/test/kotlin/de/neuefische/backend/user/UserControllerTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/user/UserControllerTest.kt
@@ -34,8 +34,10 @@ class UserControllerTest {
         userRepo.deleteAll()
     }
 
+    // --- GET /api/user/ ---
+
     @Test
-    fun getUserByName() {
+    fun `should return user by name`() {
         // Given
         val user =
             User(
@@ -63,7 +65,7 @@ class UserControllerTest {
     }
 
     @Test
-    fun getUserByNameWithoutOptionalFields() {
+    fun `should return user by name without optional fields`() {
         // Given
         val user =
             User(
@@ -87,7 +89,7 @@ class UserControllerTest {
     }
 
     @Test
-    fun getUserByNameReturnsNotFound() {
+    fun `should return not found when user by name does not exist`() {
         // When
         val result = mockMvc.perform(get("/api/user/").param("name", "test-user"))
 
@@ -96,7 +98,7 @@ class UserControllerTest {
     }
 
     @Test
-    fun getUserById() {
+    fun `should return user by id`() {
         // Given
         val userId = BsonObjectId()
         val user =
@@ -110,7 +112,8 @@ class UserControllerTest {
         userRepo.save(user)
 
         // When
-        val result = mockMvc.perform(get("/api/user/").param("id", userId.value.toString()))
+        val result =
+            mockMvc.perform(get("/api/user/").param("id", userId.value.toString()))
 
         // Then
         result
@@ -125,7 +128,7 @@ class UserControllerTest {
     }
 
     @Test
-    fun getUserByIdWithoutOptionalFields() {
+    fun `should return user by id without optional fields`() {
         // Given
         val userId = BsonObjectId()
         val user =
@@ -136,7 +139,8 @@ class UserControllerTest {
         userRepo.save(user)
 
         // When
-        val result = mockMvc.perform(get("/api/user/").param("id", userId.value.toString()))
+        val result =
+            mockMvc.perform(get("/api/user/").param("id", userId.value.toString()))
 
         // Then
         result
@@ -150,19 +154,20 @@ class UserControllerTest {
     }
 
     @Test
-    fun getUserByIdReturnsNotFound() {
+    fun `should return not found when user by id does not exist`() {
         // Given
         val userId = BsonObjectId()
 
         // When
-        val result = mockMvc.perform(get("/api/user/").param("id", userId.value.toString()))
+        val result =
+            mockMvc.perform(get("/api/user/").param("id", userId.value.toString()))
 
         // Then
         result.andExpect(status().isNotFound)
     }
 
     @Test
-    fun getUserWithoutParametersReturnsBadRequest() {
+    fun `should return bad request when no parameters are provided`() {
         // When
         val result = mockMvc.perform(get("/api/user/"))
 

--- a/backend/src/test/kotlin/de/neuefische/backend/user/UserServiceTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/user/UserServiceTest.kt
@@ -1,6 +1,7 @@
 package de.neuefische.backend.user
 
 import de.neuefische.backend.common.Medium
+import de.neuefische.backend.exceptions.NotFoundException
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -243,10 +244,10 @@ class UserServiceTest {
 
         // When / Then
         val exception =
-            assertFailsWith<IllegalArgumentException> {
+            assertFailsWith<NotFoundException> {
                 userService.updateUser(userId, updateRequest)
             }
-        assertEquals("User not found", exception.message)
+        assertEquals("User $userId not found", exception.message)
         verify(exactly = 0) { userRepo.save(any()) }
     }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,13 +11,15 @@ import { useEffect, useState } from "react";
 import axios from "axios";
 
 function App() {
-  const [username, setUsername] = useState<string | undefined>();
+  const [loggedInUsername, setLoggedInUsername] = useState<
+    string | undefined
+  >();
   const navigate = useNavigate();
 
   async function loadUser() {
     try {
       const response = await axios.get<string>("/api/auth/me");
-      setUsername(response.data);
+      setLoggedInUsername(response.data);
     } catch (error) {
       console.error("Failed to load user", error);
     }
@@ -25,7 +27,7 @@ function App() {
 
   function logout() {
     localStorage.removeItem("token");
-    setUsername(undefined);
+    setLoggedInUsername(undefined);
     void navigate("/");
   }
 
@@ -35,13 +37,19 @@ function App() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header logout={logout} username={username} />
+      <Header logout={logout} username={loggedInUsername} />
       <main className="container mx-auto px-4 py-8 mt-16">
         <Routes>
-          <Route path="/" element={<LandingPage username={username} />} />
-          <Route element={<ProtectedRoutes username={username} />}>
+          <Route
+            path="/"
+            element={<LandingPage username={loggedInUsername} />}
+          />
+          <Route element={<ProtectedRoutes username={loggedInUsername} />}>
             <Route path="/feed" element={<Feed />} />
-            <Route path="/user/:username?" element={<ProfilePage />} />
+            <Route
+              path="/user/:username?"
+              element={<ProfilePage loggedInUsername={loggedInUsername} />}
+            />
             <Route path="/woa/:workOfArtId?" element={<WorkOfArtPage />} />
           </Route>
         </Routes>

--- a/frontend/src/components/ProfileComponent.tsx
+++ b/frontend/src/components/ProfileComponent.tsx
@@ -4,9 +4,13 @@ import { User, UserEditRequestPayload, Medium } from "../types.tsx";
 
 type UserProfileProps = {
   username?: string;
+  loggedInUsername?: string;
 };
 
-export default function UserProfile({ username }: UserProfileProps) {
+export default function UserProfile({
+  username,
+  loggedInUsername,
+}: UserProfileProps) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -82,12 +86,16 @@ export default function UserProfile({ username }: UserProfileProps) {
   if (!user)
     return <div className="mt-24 text-center">No user data available</div>;
 
+  const isOwnProfile = username === loggedInUsername;
+
   return (
     <div className="container mx-auto px-4 mt-24">
       <div className="max-w-2xl mx-auto space-y-6">
-        <button onClick={handleEdit} className="text-blue-500">
-          Edit 📝
-        </button>
+        {isOwnProfile && (
+          <button onClick={handleEdit} className="text-blue-500">
+            Edit 📝
+          </button>
+        )}
         {/* Profile Section */}
         <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
           <h2 className="text-2xl font-semibold text-gray-800">{user.name}</h2>

--- a/frontend/src/components/ProfileComponent.tsx
+++ b/frontend/src/components/ProfileComponent.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
-import { User } from "../types.tsx";
+import { User, UserEditRequestPayload, Medium } from "../types.tsx";
 
 type UserProfileProps = {
   username?: string;
@@ -10,6 +10,8 @@ export default function UserProfile({ username }: UserProfileProps) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [formData, setFormData] = useState<User | null>(null);
 
   useEffect(() => {
     async function fetchUser(username: string | undefined) {
@@ -26,6 +28,7 @@ export default function UserProfile({ username }: UserProfileProps) {
           },
         });
         setUser(response.data);
+        setFormData(response.data);
         setError(null); // ✅ Clear previous errors on success
       } catch (error) {
         setError(error instanceof Error ? error.message : String(error));
@@ -37,6 +40,42 @@ export default function UserProfile({ username }: UserProfileProps) {
     void fetchUser(username);
   }, [username]);
 
+  const handleEdit = () => {
+    setIsEditing(true);
+  };
+
+  const handleSave = async () => {
+    if (!formData) return;
+
+    const payload: UserEditRequestPayload = {
+      bio: formData.bio,
+      imageUrl: formData.imageUrl,
+      mediums: formData.mediums,
+    };
+
+    try {
+      await axios.put(`/api/user/${user?.id}`, payload);
+      setUser(formData);
+      setIsEditing(false);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value } as User);
+  };
+
+  const handleMediumChange = (medium: Medium) => {
+    if (!formData) return;
+    const updatedMediums = formData.mediums.includes(medium)
+      ? formData.mediums.filter((m) => m !== medium)
+      : [...formData.mediums, medium];
+    setFormData({ ...formData, mediums: updatedMediums });
+  };
+
   if (loading) return <div className="mt-24 text-center">Loading...</div>;
   if (error)
     return <div className="mt-24 text-center text-red-500">Error: {error}</div>;
@@ -46,6 +85,9 @@ export default function UserProfile({ username }: UserProfileProps) {
   return (
     <div className="container mx-auto px-4 mt-24">
       <div className="max-w-2xl mx-auto space-y-6">
+        <button onClick={handleEdit} className="text-blue-500">
+          Edit 📝
+        </button>
         {/* Profile Section */}
         <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
           <h2 className="text-2xl font-semibold text-gray-800">{user.name}</h2>
@@ -54,13 +96,35 @@ export default function UserProfile({ username }: UserProfileProps) {
         {/* Bio Section */}
         <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
           <h3 className="text-xl font-semibold text-gray-800 mb-4">Bio</h3>
-          <p className="text-gray-600">{user.bio || "No bio yet 🌳"}</p>
+          {isEditing ? (
+            <textarea
+              name="bio"
+              value={formData?.bio || ""}
+              onChange={handleChange}
+              className="w-full bg-transparent border-none focus:outline-none"
+            />
+          ) : (
+            <p className="text-gray-600">{user.bio || "No bio yet 🌳"}</p>
+          )}
         </div>
 
         {/* Mediums Section */}
         <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
           <h3 className="text-xl font-semibold text-gray-800 mb-4">Mediums</h3>
-          {user.mediums && user.mediums.length > 0 ? (
+          {isEditing ? (
+            <div className="space-y-2">
+              {Object.values(Medium).map((medium) => (
+                <label key={medium} className="flex items-center space-x-2">
+                  <input
+                    type="checkbox"
+                    checked={formData?.mediums.includes(medium) || false}
+                    onChange={() => handleMediumChange(medium)}
+                  />
+                  <span className="text-gray-600">{medium}</span>
+                </label>
+              ))}
+            </div>
+          ) : user.mediums && user.mediums.length > 0 ? (
             <ul className="space-y-2">
               {user.mediums.map((medium) => (
                 <li
@@ -75,6 +139,12 @@ export default function UserProfile({ username }: UserProfileProps) {
             <p className="text-gray-600">No mediums yet 🖌️</p>
           )}
         </div>
+
+        {isEditing && (
+          <button onClick={() => void handleSave()} className="text-blue-500">
+            Save
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -14,7 +14,7 @@ export default function ProfilePage({ username }: ProfilePageProps) {
   }
 
   return (
-    <div>
+    <div className="container mx-auto px-4 mt-24 pb-24">
       <UserProfile username={displayUsername} />
     </div>
   );

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -2,20 +2,19 @@ import UserProfile from "../components/ProfileComponent.tsx";
 import { useParams } from "react-router-dom";
 
 type ProfilePageProps = {
-  username: string | undefined;
+  loggedInUsername: string | undefined;
 };
 
-export default function ProfilePage({ username }: ProfilePageProps) {
-  const { username: paramUsername } = useParams<{ username: string }>();
-  const displayUsername = paramUsername || username;
+export default function ProfilePage({ loggedInUsername }: ProfilePageProps) {
+  const { username } = useParams<{ username: string }>();
 
-  if (!displayUsername) {
+  if (!username) {
     return <div>User not found</div>;
   }
 
   return (
     <div className="container mx-auto px-4 mt-24 pb-24">
-      <UserProfile username={displayUsername} />
+      <UserProfile username={username} loggedInUsername={loggedInUsername} />
     </div>
   );
 }

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -11,7 +11,7 @@ export enum Medium {
   PAN_PASTELS = "pan pastels",
   PASTELS = "pastels",
   PENCILS = "pencils",
-  WATERCOLORS = "watercolor",
+  WATERCOLORS = "watercolors",
 }
 
 export type User = {

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -22,6 +22,12 @@ export type User = {
   mediums: Medium[];
 };
 
+export type UserEditRequestPayload = {
+  bio: string | null;
+  imageUrl: string | null;
+  mediums: Medium[];
+};
+
 export type Material = {
   name: string;
   identifier: string | null;


### PR DESCRIPTION
Closes: #17 

With this PR, editing capabilities are added for one's own user profile.
If one tries to edit a profile while not authenticated, they will get a 401, and one tries to edit someone else's profile, they will get a 403.
In any case, the frontend will show an Edit button only on one's own profile.

My profile

<img width="833" alt="image" src="https://github.com/user-attachments/assets/ecdd7341-025f-4a99-8524-cf43f9fce716" />

Edit mode

<img width="833" alt="image" src="https://github.com/user-attachments/assets/9d00b01c-552d-4fd7-8a9f-3474fb3680da" />
<img width="833" alt="image" src="https://github.com/user-attachments/assets/b17850c4-a0f9-476e-8889-2e7982f8f36d" />

Someone else's profile

<img width="833" alt="image" src="https://github.com/user-attachments/assets/61f6a991-2e0d-4392-8250-7ba5513a3060" />

