### PR TITLE
feat: Delete work of art

### DIFF
--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtController.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtController.kt
@@ -3,6 +3,7 @@ package de.neuefische.backend.woa
 import de.neuefische.backend.common.Medium
 import de.neuefische.backend.common.toMedium
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -59,5 +60,13 @@ class WorkOfArtController(
     ): ResponseEntity<WorkOfArtResponse> {
         val workOfArt = workOfArtService.updateWorkOfArt(id, request)
         return ResponseEntity.ok(workOfArt)
+    }
+
+    @DeleteMapping("/{id}")
+    fun deleteWorkOfArt(
+        @PathVariable id: String,
+    ): ResponseEntity<String> {
+        val deletedWoAid = workOfArtService.deleteWorkOfArt(id)
+        return ResponseEntity.ok(deletedWoAid)
     }
 }

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtService.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtService.kt
@@ -134,4 +134,12 @@ class WorkOfArtService(
         val savedWorkOfArt = workOfArtRepo.save(updatedWorkOfArt)
         return workOfArtResponse(savedWorkOfArt)
     }
+
+    fun deleteWorkOfArt(id: String): String {
+        if (!workOfArtRepo.existsById(id)) {
+            throw IllegalArgumentException("Work of Art not found")
+        }
+        workOfArtRepo.deleteById(id)
+        return id
+    }
 }

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtService.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtService.kt
@@ -5,6 +5,7 @@ import de.neuefische.backend.common.toMedium
 import org.bson.BsonObjectId
 import org.bson.types.ObjectId
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.stereotype.Service
 
 @Service
@@ -114,10 +115,15 @@ class WorkOfArtService(
     fun updateWorkOfArt(
         id: String,
         request: WorkOfArtCreateOrUpdateRequest,
+        currentUser: String,
     ): WorkOfArtResponse {
         val existingWorkOfArt =
             workOfArtRepo.findByIdOrNull(id)
                 ?: throw IllegalArgumentException("Work of Art not found")
+
+        if (currentUser != existingWorkOfArt.userName) {
+            throw AccessDeniedException("You can update only your own work of art")
+        }
 
         val updatedWorkOfArt =
             constructWorkOfArt(
@@ -135,10 +141,18 @@ class WorkOfArtService(
         return workOfArtResponse(savedWorkOfArt)
     }
 
-    fun deleteWorkOfArt(id: String): String {
-        if (!workOfArtRepo.existsById(id)) {
-            throw IllegalArgumentException("Work of Art not found")
+    fun deleteWorkOfArt(
+        id: String,
+        currentUser: String,
+    ): String {
+        val existingWorkOfArt =
+            workOfArtRepo.findByIdOrNull(id)
+                ?: throw IllegalArgumentException("Work of Art not found")
+
+        if (currentUser != existingWorkOfArt.userName) {
+            throw AccessDeniedException("You can delete only your own work of art")
         }
+
         workOfArtRepo.deleteById(id)
         return id
     }

--- a/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtControllerTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtControllerTest.kt
@@ -11,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -426,7 +427,12 @@ class WorkOfArtControllerTest {
             mockMvc.perform(
                 put("/api/woa/${yellowSunset.id.value}")
                     .contentType("application/json")
-                    .content(requestContent),
+                    .content(requestContent)
+                    .with(
+                        oauth2Login().attributes { attrs ->
+                            attrs["login"] = yellowSunset.userName
+                        },
+                    ),
             )
 
         // Then
@@ -478,9 +484,48 @@ class WorkOfArtControllerTest {
     }
 
     @Test
+    fun `should throw error when editing another user's work of art`() {
+        // Given
+        val requestContent =
+            """
+            {
+                "user": "${yellowSunset.user.value}",
+                "userName": "${yellowSunset.userName}",
+                "title": "Updated Title",
+                "imageUrl": "https://example.com/updated-image.jpg",
+                "medium": "pencils"
+            }
+            """.trimIndent()
+
+        // When
+        val result =
+            mockMvc.perform(
+                put("/api/woa/${yellowSunset.id.value}")
+                    .contentType("application/json")
+                    .content(requestContent)
+                    .with(
+                        oauth2Login().attributes { attrs ->
+                            attrs["login"] = "another-user"
+                        },
+                    ),
+            )
+
+        // Then
+        result
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
     fun `should delete work of art`() {
         // When
-        val result = mockMvc.perform(delete("/api/woa/${yellowSunset.id.value}"))
+        val result =
+            mockMvc.perform(
+                delete("/api/woa/${yellowSunset.id.value}").with(
+                    oauth2Login().attributes { attrs ->
+                        attrs["login"] = yellowSunset.userName
+                    },
+                ),
+            )
 
         // Then
         result
@@ -505,5 +550,24 @@ class WorkOfArtControllerTest {
         result
             .andExpect(status().isBadRequest)
             .andExpect(jsonPath("$.message").value("Work of Art not found"))
+    }
+
+    @Test
+    fun `should throw error when deleting another user's work of art`() {
+        // When
+        val result =
+            mockMvc.perform(
+                delete("/api/woa/${yellowSunset.id.value}").with(
+                    oauth2Login().attributes { attrs ->
+                        attrs["login"] = "another-user"
+                    },
+                ),
+            )
+
+        println(result)
+
+        // Then
+        result
+            .andExpect(status().isForbidden)
     }
 }

--- a/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtControllerTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtControllerTest.kt
@@ -12,6 +12,7 @@ import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
@@ -469,6 +470,36 @@ class WorkOfArtControllerTest {
                     .contentType("application/json")
                     .content(requestContent),
             )
+
+        // Then
+        result
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.message").value("Work of Art not found"))
+    }
+
+    @Test
+    fun `should delete work of art`() {
+        // When
+        val result = mockMvc.perform(delete("/api/woa/${yellowSunset.id.value}"))
+
+        // Then
+        result
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$").value(yellowSunset.id.value.toString()))
+
+        // When
+        mockMvc
+            .perform(get("/api/woa/${yellowSunset.id.value}"))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `should throw error when deleting nonexistent work of art`() {
+        // Given
+        val nonexistentId = BsonObjectId().value.toString()
+
+        // When
+        val result = mockMvc.perform(delete("/api/woa/$nonexistentId"))
 
         // Then
         result

--- a/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
@@ -3,6 +3,7 @@ package de.neuefische.backend.woa
 import de.neuefische.backend.common.Medium
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.bson.BsonObjectId
 import org.bson.types.ObjectId
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -468,5 +469,33 @@ class WorkOfArtServiceTest {
                 workOfArtService.updateWorkOfArt(nonexistentId, request)
             }
         assertEquals("Work of Art not found", exception.message)
+    }
+
+    @Test
+    fun `should delete work of art`() {
+        // Given
+        val id = yellowSunset.id.value.toString()
+        every { workOfArtRepo.existsById(id) } returns true
+        every { workOfArtRepo.deleteById(id) } returns Unit
+
+        // When
+        val res = workOfArtService.deleteWorkOfArt(yellowSunset.id.value.toString())
+
+        // Then
+        assertEquals(res, id)
+        verify { workOfArtRepo.deleteById(id) }
+    }
+
+    @Test
+    fun `should throw error when deleting nonexistent work of art`() {
+        // Given
+        val nonexistentId = BsonObjectId().value.toString()
+        every { workOfArtRepo.existsById(nonexistentId) } returns false
+
+        // When / Then
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                workOfArtService.deleteWorkOfArt(nonexistentId)
+            }
     }
 }

--- a/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.security.access.AccessDeniedException
 
 class WorkOfArtServiceTest {
     private val workOfArtRepo = mockk<WorkOfArtRepo>()
@@ -419,7 +420,11 @@ class WorkOfArtServiceTest {
 
         // When
         val result =
-            workOfArtService.updateWorkOfArt(yellowSunset.id.value.toString(), request)
+            workOfArtService.updateWorkOfArt(
+                yellowSunset.id.value.toString(),
+                request,
+                yellowSunset.userName,
+            )
 
         // Then
         val expectedResponse =
@@ -466,20 +471,60 @@ class WorkOfArtServiceTest {
         // When / Then
         val exception =
             assertThrows<IllegalArgumentException> {
-                workOfArtService.updateWorkOfArt(nonexistentId, request)
+                workOfArtService.updateWorkOfArt(nonexistentId, request, "someUserName")
             }
         assertEquals("Work of Art not found", exception.message)
+    }
+
+    @Test
+    fun `should throw error when editing another user's work of art`() {
+        // Given
+        val request =
+            WorkOfArtCreateOrUpdateRequest(
+                user = yellowSunset.user.value.toString(),
+                userName = yellowSunset.userName,
+                title = "Updated Title",
+                imageUrl = "https://example.com/updated-image.jpg",
+                medium = "pencils",
+                materials =
+                    listOf(
+                        MaterialDAO(
+                            name = "Updated Material",
+                            identifier = "99",
+                            brand = "Updated Brand",
+                            line = "Updated Line",
+                            type = "Updated Type",
+                            medium = "pencils",
+                        ),
+                    ),
+            )
+
+        every { workOfArtRepo.findByIdOrNull(yellowSunset.id.value.toString()) } returns yellowSunset
+
+        // When / Then
+        assertThrows<AccessDeniedException> {
+            workOfArtService.updateWorkOfArt(
+                yellowSunset.id.value.toString(),
+                request,
+                "someOtherUserName",
+            )
+        }
+        verify(exactly = 0) { workOfArtRepo.save(any()) }
     }
 
     @Test
     fun `should delete work of art`() {
         // Given
         val id = yellowSunset.id.value.toString()
-        every { workOfArtRepo.existsById(id) } returns true
+        every { workOfArtRepo.findByIdOrNull(id) } returns yellowSunset
         every { workOfArtRepo.deleteById(id) } returns Unit
 
         // When
-        val res = workOfArtService.deleteWorkOfArt(yellowSunset.id.value.toString())
+        val res =
+            workOfArtService.deleteWorkOfArt(
+                yellowSunset.id.value.toString(),
+                yellowSunset.userName,
+            )
 
         // Then
         assertEquals(res, id)
@@ -490,12 +535,25 @@ class WorkOfArtServiceTest {
     fun `should throw error when deleting nonexistent work of art`() {
         // Given
         val nonexistentId = BsonObjectId().value.toString()
-        every { workOfArtRepo.existsById(nonexistentId) } returns false
+        every { workOfArtRepo.findByIdOrNull(nonexistentId) } returns null
 
         // When / Then
-        val exception =
-            assertThrows<IllegalArgumentException> {
-                workOfArtService.deleteWorkOfArt(nonexistentId)
-            }
+        assertThrows<IllegalArgumentException> {
+            workOfArtService.deleteWorkOfArt(nonexistentId, "someUserName")
+        }
+    }
+
+    @Test
+    fun `should throw error when deleting different user's work of art`() {
+        // Given
+        val id = yellowSunset.id.value.toString()
+        every { workOfArtRepo.findByIdOrNull(id) } returns yellowSunset
+
+        // When / Then
+        assertThrows<AccessDeniedException> {
+            workOfArtService.deleteWorkOfArt(id, "someOtherUserName")
+        }
+
+        verify(exactly = 0) { workOfArtRepo.deleteById(id) }
     }
 }

--- a/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtServiceTest.kt
@@ -541,6 +541,8 @@ class WorkOfArtServiceTest {
         assertThrows<IllegalArgumentException> {
             workOfArtService.deleteWorkOfArt(nonexistentId, "someUserName")
         }
+
+        verify(exactly = 0) { workOfArtRepo.deleteById(nonexistentId) }
     }
 
     @Test

--- a/frontend/src/components/WorkOfArtForm.tsx
+++ b/frontend/src/components/WorkOfArtForm.tsx
@@ -222,6 +222,26 @@ export default function WorkOfArtForm({
     }
   };
 
+  const handleDelete = async () => {
+    if (!workOfArtId) return;
+
+    try {
+      const response = await fetch(`/api/woa/${workOfArtId}`, {
+        method: "DELETE",
+      });
+
+      if (!response.ok) {
+        setError(`HTTP error! status: ${response.status}`);
+        return;
+      }
+
+      onSuccess?.();
+      window.location.href = "/feed";
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    }
+  };
+
   return (
     <div className="container mx-auto px-4 mt-24">
       <div className="max-w-2xl mx-auto space-y-6">
@@ -341,6 +361,15 @@ export default function WorkOfArtForm({
           )}
 
           <div style={{ display: "flex", justifyContent: "center" }}>
+            {isEditMode && (
+              <button
+                type="button"
+                onClick={handleDelete}
+                className="mt-4 mr-4 px-4 py-2 bg-red-500 text-white rounded-lg"
+              >
+                Delete
+              </button>
+            )}
             <button
               type="submit"
               disabled={isSubmitting}


### PR DESCRIPTION
Closes: #36 

With this PR, a Delete button is added to the edit mode of the work of art. Once deleted, the user is redirected to the feed.
Additionally, the backend allows both edits and deletes only by the owner of the work of art.

**Screenshot**

![image](https://github.com/user-attachments/assets/3a3cbeda-3ba0-4df3-bc36-ee613aa6ea24)
