### PR TITLE
fix: Use toMedium method to convert string to medium in material

### DIFF
--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtService.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtService.kt
@@ -91,7 +91,9 @@ class WorkOfArtService(
                         brand = material.brand,
                         line = material.line,
                         type = material.type,
-                        medium = material.medium?.let { Medium.valueOf(it.uppercase()) },
+                        medium =
+                            medium.toMedium()
+                                ?: throw IllegalArgumentException("Medium is unavailable"),
                     )
                 },
         )

--- a/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtControllerTest.kt
+++ b/backend/src/test/kotlin/de/neuefische/backend/woa/WorkOfArtControllerTest.kt
@@ -328,7 +328,7 @@ class WorkOfArtControllerTest {
                                     "brand": "Schmincke",
                                     "line": "Horadam",
                                     "type": "Half Pan",
-                                    "medium": "watercolors"
+                                    "medium": "color pencils"
                                 },
                                 {
                                     "name": "Round Brush",


### PR DESCRIPTION
Fixes: #41

When I was demoing the feature, I got a 400 because it could not find a corresponding medium to "color pencils". 

With this PR, the conversion from string to Medium enum for materials is fixed. 

