### PR TITLE
fix: Users should be redirected to the landing page in case of a 401

### DIFF
--- a/backend/src/main/kotlin/de/neuefische/backend/security/SecurityConfig.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/security/SecurityConfig.kt
@@ -26,11 +26,11 @@ class SecurityConfig(
                 it.requestMatchers("/api/status").permitAll()
                 it.anyRequest().permitAll()
             }.sessionManagement {
-                it.sessionCreationPolicy(SessionCreationPolicy.ALWAYS)
+                it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             }.exceptionHandling {
                 it.authenticationEntryPoint(HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
             }.oauth2Login {
-                it.defaultSuccessUrl("$clientUrl/feed")
+                it.defaultSuccessUrl("$clientUrl/feed", true)
             }.logout {
                 it.logoutSuccessUrl(clientUrl)
             }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,19 @@ import { useEffect, useState } from "react";
 import axios from "axios";
 import NewWorkOfArtPage from "./pages/NewWorkOfArtPage.tsx";
 
+axios.interceptors.response.use(
+  (response) => response,
+  (error: unknown) => {
+    if (axios.isAxiosError(error) && error.response?.status === 401) {
+      localStorage.removeItem("token");
+      window.location.href = "/";
+    }
+    return Promise.reject(
+      new Error(error instanceof Error ? error.message : "An error occurred"),
+    );
+  },
+);
+
 function App() {
   const [loggedInUsername, setLoggedInUsername] = useState<
     string | undefined

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -78,11 +78,11 @@ function App() {
                 />
               }
             />
+            <Route
+              path="/woa/:workOfArtId?"
+              element={<WorkOfArtPage loggedInUsername={loggedInUsername} />}
+            />
           </Route>
-          <Route
-            path="/woa/:workOfArtId?"
-            element={<WorkOfArtPage loggedInUsername={loggedInUsername} />}
-          />
         </Routes>
       </main>
       <Footer />

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -4,12 +4,11 @@ type ProtectedRouteProps = {
   username: string | undefined;
 };
 
-export default function ProtectedRoutes(
-  username: Readonly<ProtectedRouteProps>,
-) {
+export default function ProtectedRoutes({
+  username,
+}: Readonly<ProtectedRouteProps>) {
   if (!username) {
     return <Navigate to="/" replace />;
   }
-
   return <Outlet />;
 }


### PR DESCRIPTION
With this PR:
- users are redirected to the landing page in case of a 401
- in success cases, they are redirected to /feed every time

Tested manually in the local env.