### PR TITLE
fix: Make the content go below the header bar not above

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -21,7 +21,7 @@ export default function Header({ logout, username }: HeaderProps) {
   ];
 
   return (
-    <header className="fixed top-0 left-0 right-0 bg-white/80 backdrop-blur-sm shadow-sm">
+    <header className="fixed top-0 left-0 right-0 bg-white/80 backdrop-blur-sm shadow-sm z-10">
       <div className="container mx-auto px-4">
         <div className="flex justify-between items-center h-20">
           {/* Logo */}

--- a/frontend/src/components/PageContainer.tsx
+++ b/frontend/src/components/PageContainer.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from "react";
+
+type PageContainerProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export default function PageContainer({
+  children,
+  className = "",
+}: PageContainerProps) {
+  return (
+    <div
+      className={`relative z-0 container mx-auto px-4 mt-24 pb-24 ${className}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/pages/Feed.tsx
+++ b/frontend/src/pages/Feed.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import axios from "axios";
 import WorkOfArtComponent from "../components/WorkOfArtComponent";
 import { WorkOfArt } from "../types.tsx";
+import PageContainer from "../components/PageContainer.tsx";
 
 export default function Feed() {
   const [worksOfArt, setWorksOfArt] = useState<WorkOfArt[]>([]);
@@ -24,12 +25,21 @@ export default function Feed() {
     void fetchWorksOfArt();
   }, []);
 
-  if (loading) return <div className="mt-24 text-center">Loading...</div>;
+  if (loading)
+    return (
+      <PageContainer>
+        <div className="mt-24 text-center">Loading...</div>
+      </PageContainer>
+    );
   if (error)
-    return <div className="mt-24 text-center text-red-500">Error: {error}</div>;
+    return (
+      <PageContainer>
+        <div className="mt-24 text-center text-red-500">Error: {error}</div>
+      </PageContainer>
+    );
 
   return (
-    <div className="container mx-auto px-4 mt-24 pb-24">
+    <PageContainer>
       <div className="max-w-2xl mx-auto space-y-6">
         {worksOfArt.map((workOfArt) => (
           <WorkOfArtComponent
@@ -39,6 +49,6 @@ export default function Feed() {
           />
         ))}
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/frontend/src/pages/NewWorkOfArtPage.tsx
+++ b/frontend/src/pages/NewWorkOfArtPage.tsx
@@ -1,5 +1,6 @@
 import WorkOfArtForm from "../components/WorkOfArtForm.tsx";
 import { useNavigate } from "react-router-dom";
+import PageContainer from "../components/PageContainer.tsx";
 
 export default function NewWorkOfArtPage({
   userId,
@@ -11,7 +12,7 @@ export default function NewWorkOfArtPage({
   const navigate = useNavigate();
 
   return (
-    <div className="container mx-auto px-4 mt-24 pb-24">
+    <PageContainer>
       <WorkOfArtForm
         user={userId}
         userName={username}
@@ -19,6 +20,6 @@ export default function NewWorkOfArtPage({
           void navigate("/feed");
         }}
       />
-    </div>
+    </PageContainer>
   );
 }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,5 +1,6 @@
 import UserProfile from "../components/ProfileComponent.tsx";
 import { useParams } from "react-router-dom";
+import PageContainer from "../components/PageContainer.tsx";
 
 type ProfilePageProps = {
   loggedInUsername: string | undefined;
@@ -9,12 +10,16 @@ export default function ProfilePage({ loggedInUsername }: ProfilePageProps) {
   const { username } = useParams<{ username: string }>();
 
   if (!username) {
-    return <div>User not found</div>;
+    return (
+      <PageContainer>
+        <div>User not found</div>
+      </PageContainer>
+    );
   }
 
   return (
-    <div className="container mx-auto px-4 mt-24 pb-24">
+    <PageContainer>
       <UserProfile username={username} loggedInUsername={loggedInUsername} />
-    </div>
+    </PageContainer>
   );
 }

--- a/frontend/src/pages/WorkOfArtPage.tsx
+++ b/frontend/src/pages/WorkOfArtPage.tsx
@@ -4,6 +4,7 @@ import axios from "axios";
 import WorkOfArtComponent from "../components/WorkOfArtComponent.tsx";
 import WorkOfArtForm from "../components/WorkOfArtForm.tsx";
 import { WorkOfArt } from "../types.tsx";
+import PageContainer from "../components/PageContainer.tsx";
 
 type WorkOfArtPageProps = {
   loggedInUsername: string | undefined;
@@ -45,18 +46,29 @@ export default function WorkOfArtPage({
     window.location.href = `/woa/${workOfArtId}`;
   };
 
-  if (loading) return <div className="mt-24 text-center">Loading...</div>;
+  if (loading)
+    return (
+      <PageContainer>
+        <div className="text-center">Loading...</div>
+      </PageContainer>
+    );
   if (error)
-    return <div className="mt-24 text-center text-red-500">Error: {error}</div>;
+    return (
+      <PageContainer>
+        <div className="text-center text-red-500">Error: {error}</div>
+      </PageContainer>
+    );
   if (!workOfArt)
     return (
-      <div className="mt-24 text-center">No work of art data available</div>
+      <PageContainer>
+        <div className="text-center">No work of art data available</div>
+      </PageContainer>
     );
 
   const isOwnProfile = workOfArt.userName === loggedInUsername;
 
   return (
-    <div className="pb-24">
+    <PageContainer>
       {isEditMode ? (
         <WorkOfArtForm
           user={workOfArt.user}
@@ -84,6 +96,6 @@ export default function WorkOfArtPage({
           <WorkOfArtComponent workOfArt={workOfArt} />
         </>
       )}
-    </div>
+    </PageContainer>
   );
 }


### PR DESCRIPTION
Fixes: #16

With this PR, the page content, when scrolling, goes below the header instead of above.
The code is refactored to have this property as a reusable component.

**Screenshot**
<img width="923" alt="image" src="https://github.com/user-attachments/assets/3dc4a958-6cea-428c-a8bc-9267e3a195ef" />
