### PR TITLE
fix: Revert session policy change

### DIFF
--- a/backend/src/main/kotlin/de/neuefische/backend/security/SecurityConfig.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/security/SecurityConfig.kt
@@ -26,7 +26,7 @@ class SecurityConfig(
                 it.requestMatchers("/api/status").permitAll()
                 it.anyRequest().permitAll()
             }.sessionManagement {
-                it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                it.sessionCreationPolicy(SessionCreationPolicy.ALWAYS)
             }.exceptionHandling {
                 it.authenticationEntryPoint(HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
             }.oauth2Login {


### PR DESCRIPTION
Fixes: #49

With this PR, the session policy change is reverted, because it wasn't allowing github to log in properly.

Not even sure why this worked in the first place 🤷‍♀️
