### PR TITLE
fix: Pass empty string instead of undefined to protected routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,10 +25,10 @@ axios.interceptors.response.use(
 );
 
 function App() {
-  const [loggedInUsername, setLoggedInUsername] = useState<
-    string | undefined
-  >();
+  const [loggedInUsername, setLoggedInUsername] = useState<string>("");
+  const [isLoading, setIsLoading] = useState(true);
   const [loggedInUserId, setLoggedInUserId] = useState<string | undefined>();
+
   const navigate = useNavigate();
 
   async function loadUser() {
@@ -40,12 +40,15 @@ function App() {
       setLoggedInUserId(response.data.user);
     } catch (error) {
       console.error("Failed to load user", error);
+      setLoggedInUsername("");
+    } finally {
+      setIsLoading(false);
     }
   }
 
   function logout() {
     localStorage.removeItem("token");
-    setLoggedInUsername(undefined);
+    setLoggedInUsername("");
     setLoggedInUserId(undefined);
     void navigate("/");
   }
@@ -63,7 +66,14 @@ function App() {
             path="/"
             element={<LandingPage username={loggedInUsername} />}
           />
-          <Route element={<ProtectedRoutes username={loggedInUsername} />}>
+          <Route
+            element={
+              <ProtectedRoutes
+                username={loggedInUsername}
+                isLoading={isLoading}
+              />
+            }
+          >
             <Route path="/feed" element={<Feed />} />
             <Route
               path="/user/:username?"

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,14 +1,21 @@
 import { Navigate, Outlet } from "react-router-dom";
 
 type ProtectedRouteProps = {
-  username: string | undefined;
+  username: string;
+  isLoading: boolean;
 };
 
 export default function ProtectedRoutes({
   username,
+  isLoading,
 }: Readonly<ProtectedRouteProps>) {
+  if (isLoading) {
+    return null; // TODO: loading spinner?
+  }
+
   if (!username) {
     return <Navigate to="/" replace />;
   }
+
   return <Outlet />;
 }


### PR DESCRIPTION
With this PR, the redirect is also fixed on the frontend. By passing an empty string instead of undefined when the user is not logged in yet, some unnecessary redirections are prevented.