### PR TITLE
fix: Improve look of Work of Art component

### DIFF
--- a/frontend/src/components/WorkOfArtComponent.tsx
+++ b/frontend/src/components/WorkOfArtComponent.tsx
@@ -29,26 +29,25 @@ export default function WorkOfArtComponent({
     <div className="container mx-auto px-4 mt-24">
       <div className="max-w-2xl mx-auto space-y-6">
         <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg overflow-hidden">
-          {/* User and medium section */}
+          {/* Title and medium */}
           <div className="flex justify-between p-6">
-            <h2 className="text-2xl font-semibold text-gray-800">
-              <a href={`/user/${workOfArt.userName}`}>{workOfArt.userName}</a>
-            </h2>
+            <h3 className="text-2xl font-semibold text-gray-800">
+              <a href={`/woa/${workOfArt.id}`}>{workOfArt.title}</a>
+            </h3>
+
             <p className="text-gray-600">{workOfArt.medium}</p>
           </div>
-
           {/* Image */}
           <img
             src={transformImageUrl(workOfArt.imageUrl)}
             alt={workOfArt.title}
             className="w-full"
           />
-
-          {/* Title and Date */}
+          {/* User and date */}
           <div className="flex justify-between p-6">
-            <h3 className="text-2xl font-semibold text-gray-800">
-              <a href={`/woa/${workOfArt.id}`}>{workOfArt.title}</a>
-            </h3>
+            <h2 className="text-2xl font-semibold text-gray-800">
+              <a href={`/user/${workOfArt.userName}`}>{workOfArt.userName}</a>
+            </h2>
             <p className="text-gray-600">{formatDate(workOfArt.createdAt)}</p>
           </div>
         </div>

--- a/frontend/src/components/WorkOfArtComponent.tsx
+++ b/frontend/src/components/WorkOfArtComponent.tsx
@@ -72,8 +72,12 @@ export default function WorkOfArtComponent({
                 </h3>
                 {workOfArt.materials.map((material, index) => (
                   <p key={index} className="text-gray-600">
-                    {material.type} {material.identifier} - {material.name} by{" "}
-                    {material.brand} ({material.line})
+                    {material.type}
+                    {material.identifier && ` ${material.identifier}`}
+                    {(material.type || material.identifier) && " - "}
+                    {material.name}
+                    {material.brand && ` by ${material.brand}`}
+                    {material.line && ` (${material.line})`}
                   </p>
                 ))}
               </div>

--- a/frontend/src/components/WorkOfArtComponent.tsx
+++ b/frontend/src/components/WorkOfArtComponent.tsx
@@ -28,38 +28,31 @@ export default function WorkOfArtComponent({
   return (
     <div className="container mx-auto px-4 mt-24">
       <div className="max-w-2xl mx-auto space-y-6">
-        {/* User and Medium Section */}
-        <div className="flex justify-between bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
-          <div>
+        <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg overflow-hidden">
+          {/* User and medium section */}
+          <div className="flex justify-between p-6">
             <h2 className="text-2xl font-semibold text-gray-800">
               <a href={`/user/${workOfArt.userName}`}>{workOfArt.userName}</a>
             </h2>
-          </div>
-          <div>
             <p className="text-gray-600">{workOfArt.medium}</p>
           </div>
-        </div>
 
-        {/* Image Section */}
-        <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
+          {/* Image */}
           <img
             src={transformImageUrl(workOfArt.imageUrl)}
             alt={workOfArt.title}
-            className="w-full rounded-lg"
+            className="w-full"
           />
-        </div>
 
-        {/* Title Section */}
-        <div className="flex justify-between bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
-          <div>
+          {/* Title and Date */}
+          <div className="flex justify-between p-6">
             <h3 className="text-2xl font-semibold text-gray-800">
               <a href={`/woa/${workOfArt.id}`}>{workOfArt.title}</a>
             </h3>
-          </div>
-          <div>
             <p className="text-gray-600">{formatDate(workOfArt.createdAt)}</p>
           </div>
         </div>
+
         {allFields && (
           <>
             {/* Description Section */}


### PR DESCRIPTION
Cloes: #47

With this PR, the Work of Art component looks a bit nicer:
- the title, image and author are merged in one box
- the title and medium go on top while the author and date on the bottom
- the material fields don't look badly incomplete anymore even when some of the fields are missing

Screenshots

<img width="606" alt="image" src="https://github.com/user-attachments/assets/6e392631-98ef-409d-b2d9-4d2b0ac92a9b" />


<img width="606" alt="image" src="https://github.com/user-attachments/assets/d8ac40fd-391b-43d7-a488-be803f392a27" />
