### PR TITLE
feat: Add user works of art on their profile

### DIFF
--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtController.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtController.kt
@@ -36,18 +36,19 @@ class WorkOfArtController(
         }
     }
 
-    @GetMapping()
+    @GetMapping
     fun getAllWorksOfArt(
         @RequestParam(required = false) mediums: List<String>?,
-    ): ResponseEntity<List<WorkOfArtShortResponse>> {
-        if (mediums.isNullOrEmpty()) {
-            val worksOfArt = workOfArtService.getAllWorksOfArt()
-            return ResponseEntity.ok(worksOfArt)
+        @RequestParam(required = false) userId: String?,
+    ): ResponseEntity<List<WorkOfArtShortResponse>> =
+        when {
+            userId != null -> ResponseEntity.ok(workOfArtService.getAllWorksOfArtByUser(userId))
+            mediums != null -> {
+                val foundMediums: List<Medium> = mediums.mapNotNull { it.toMedium() }
+                ResponseEntity.ok(workOfArtService.getAllWorksOfArt(foundMediums))
+            }
+            else -> ResponseEntity.ok(workOfArtService.getAllWorksOfArt())
         }
-        val foundMediums: List<Medium> = mediums.mapNotNull { it.toMedium() }
-        val worksOfArt = workOfArtService.getAllWorksOfArt(foundMediums)
-        return ResponseEntity.ok(worksOfArt)
-    }
 
     @PostMapping()
     fun createWorkOfArt(

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtRepo.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtRepo.kt
@@ -1,8 +1,11 @@
 package de.neuefische.backend.woa
 
 import de.neuefische.backend.common.Medium
+import org.bson.BsonObjectId
 import org.springframework.data.mongodb.repository.MongoRepository
 
 interface WorkOfArtRepo : MongoRepository<WorkOfArt, String> {
     fun findAllByMediumIn(mediums: List<Medium>): List<WorkOfArt>
+
+    fun findAllByUser(user: BsonObjectId): List<WorkOfArt>
 }

--- a/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtService.kt
+++ b/backend/src/main/kotlin/de/neuefische/backend/woa/WorkOfArtService.kt
@@ -36,19 +36,8 @@ class WorkOfArtService(
             createdAt = woa.createdAt.toString(),
         )
 
-    fun getWorkOfArtById(id: String): WorkOfArtResponse? =
-        workOfArtRepo.findByIdOrNull(id)?.let { workOfArt ->
-            workOfArtResponse(workOfArt)
-        }
-
-    fun getAllWorksOfArt(mediums: List<Medium>? = null): List<WorkOfArtShortResponse> {
-        val worksOfArt =
-            if (mediums.isNullOrEmpty()) {
-                workOfArtRepo.findAll()
-            } else {
-                workOfArtRepo.findAllByMediumIn(mediums)
-            }
-        return worksOfArt
+    private fun workOfArtShortResponses(worksOfArt: List<WorkOfArt>) =
+        worksOfArt
             .sortedByDescending { it.createdAt }
             .map { workOfArt ->
                 WorkOfArtShortResponse(
@@ -61,6 +50,25 @@ class WorkOfArtService(
                     createdAt = workOfArt.createdAt.toString(),
                 )
             }
+
+    fun getWorkOfArtById(id: String): WorkOfArtResponse? =
+        workOfArtRepo.findByIdOrNull(id)?.let { workOfArt ->
+            workOfArtResponse(workOfArt)
+        }
+
+    fun getAllWorksOfArt(mediums: List<Medium>? = null): List<WorkOfArtShortResponse> {
+        val worksOfArt =
+            if (mediums.isNullOrEmpty()) {
+                workOfArtRepo.findAll()
+            } else {
+                workOfArtRepo.findAllByMediumIn(mediums)
+            }
+        return workOfArtShortResponses(worksOfArt)
+    }
+
+    fun getAllWorksOfArtByUser(user: String): List<WorkOfArtShortResponse> {
+        val worksOfArt = workOfArtRepo.findAllByUser(BsonObjectId(ObjectId(user)))
+        return workOfArtShortResponses(worksOfArt)
     }
 
     private fun constructWorkOfArt(

--- a/frontend/src/components/ProfileComponent.tsx
+++ b/frontend/src/components/ProfileComponent.tsx
@@ -116,7 +116,7 @@ export default function UserProfile({
   return (
     <div className="container mx-auto px-4 mt-24">
       <div className="max-w-2xl mx-auto space-y-6">
-        {isOwnProfile && (
+        {isOwnProfile && !isEditing && (
           <div style={{ display: "flex", justifyContent: "center" }}>
             <button
               onClick={handleEdit}

--- a/frontend/src/components/ProfileComponent.tsx
+++ b/frontend/src/components/ProfileComponent.tsx
@@ -117,9 +117,14 @@ export default function UserProfile({
     <div className="container mx-auto px-4 mt-24">
       <div className="max-w-2xl mx-auto space-y-6">
         {isOwnProfile && (
-          <button onClick={handleEdit} className="text-blue-500">
-            Edit 📝
-          </button>
+          <div style={{ display: "flex", justifyContent: "center" }}>
+            <button
+              onClick={handleEdit}
+              className="mt-4 px-4 py-2 bg-blue-500 text-white rounded-lg"
+            >
+              Edit
+            </button>
+          </div>
         )}
         {/* Profile Section */}
         <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-lg p-6">
@@ -174,9 +179,14 @@ export default function UserProfile({
         </div>
 
         {isEditing && (
-          <button onClick={() => void handleSave()} className="text-blue-500">
-            Save
-          </button>
+          <div style={{ display: "flex", justifyContent: "center" }}>
+            <button
+              onClick={() => void handleSave()}
+              className="mt-4 px-4 py-2 bg-blue-500 text-white rounded-lg"
+            >
+              Save
+            </button>
+          </div>
         )}
 
         {/* Works of Art Section */}

--- a/frontend/src/pages/WorkOfArtPage.tsx
+++ b/frontend/src/pages/WorkOfArtPage.tsx
@@ -83,7 +83,7 @@ export default function WorkOfArtPage({
         />
       ) : (
         <>
-          {isOwnProfile && (
+          {isOwnProfile && !isEditMode && (
             <div style={{ display: "flex", justifyContent: "center" }}>
               <button
                 onClick={() => setIsEditMode(true)}


### PR DESCRIPTION
Closes: #12 

With this PR:
- the user's works of art are displayed on their profile
- the save and edit buttons for the profile are uniformed to those of the work of art
- the edit button is not displayed when in edit mode, also for the work of art

Screenshots - Profile
<img width="531" alt="image" src="https://github.com/user-attachments/assets/f20e21e2-8f08-484a-add4-19b5687f4004" />

<img width="531" alt="image" src="https://github.com/user-attachments/assets/cec9cb8c-116e-4674-9210-8f49add46b54" />

Screenshot - Work of Art
<img width="531" alt="image" src="https://github.com/user-attachments/assets/8276ab73-1925-433e-8fb3-c31b99792c0a" />


